### PR TITLE
Clarify portfolio pages with intro copy and alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # bseverns.github.io
 
-Currently a personal art portfolio.
+A scrappy showcase of Ben Severns's art, teaching artifacts, and other noise.
+
+## What's all this?
+* `index.html` – the landing page, linking out to studio and academic portfolios.
+* `art.html` – thumbnails of studio work; hover and click for more info.
+* `courses.html` – syllabi and teaching material, under active construction.
+* `about.html` – bio and CV.
+* `contact.html` – drop a line.
+
+## Hacking locally
+No build pipeline here. Spin up a bare-bones server with `python3 -m http.server` and open a browser to `http://localhost:8000`.
+
+## Why so many images?
+Key images now carry `alt` text to make the site friendlier to screen readers. Keep that vibe if you add more work.
+
+PRs, issues, or weird ideas welcome. Keep it noisy and accessible.

--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif">
+    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>
@@ -57,7 +57,7 @@
       <h1>About/CV</h1>
       <div class="one-column">
         <p>| Artist | Educator | Strategist |</br>| Designer | Developer | Musician |</p>
-        <img src="img/logo/self_about.jpg">
+        <img src="img/logo/self_about.jpg" alt="self portrait of Ben Severns">
       </div>
       <div class="two-column">
         <h1>About</h1>

--- a/art.html
+++ b/art.html
@@ -45,18 +45,22 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif">
+    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>
   </header>
 
   <!--Content-->
-    <ul class="portfolio-grid">
   <div class="content">
+    <div class="text-intro">
+      <h1>Studio Portfolio</h1>
+      <p>Hover a tile to get the gist. Click through if you want the full noise.</p>
+    </div>
+    <ul class="portfolio-grid">
 
 <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/truth.jpg">
+  <img src="img/portfolio/3d/truth.jpg" alt="We hold these truths artwork thumbnail">
   <a href="3d/truth.html">
     <div class="grid-hover">
       <h1>We hold these truths</h1>
@@ -83,7 +87,7 @@
 
 <!--Construct/Obstruct-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="3d/full3d/conob.jpeg">
+  <img src="3d/full3d/conob.jpeg" alt="Construct//Obstruct artwork thumbnail">
   <a href="3d/con.html">
     <div class="grid-hover">
       <h1>Construct//Obstruct</h1>
@@ -100,7 +104,7 @@
 
 <!--context-->
 <li class="grid-item" data-jkit="[show:delay=3750;speed=500;animation=fade]">
-  <img src="img/front/context.jpg">
+  <img src="img/front/context.jpg" alt="CONTEXT sketchbook thumbnail">
   <a href="http://bseverns.tumblr.com" target="_blank">
     <div class="grid-hover">
       <h1>CONTEXT</h1>
@@ -116,7 +120,7 @@
 
 <!--Tonal Dissonance-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/hook.jpg">
+  <img src="img/portfolio/3d/hook.jpg" alt="Tonal dissonance artwork thumbnail">
   <a href="3d/redstairs.html">
     <div class="grid-hover">
       <h1>Tonal dissonance</h1>
@@ -132,7 +136,7 @@
 
 <!--Jackass-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/ex1.jpg">
+  <img src="img/portfolio/flat/ex1.jpg" alt="Jackass artwork thumbnail">
   <a href="2d/divine.html">
     <div class="grid-hover">
       <h1>Jackass(Experiments in rendering the divine)</h1>
@@ -142,7 +146,7 @@
 
 <!--I hope you choke-->
 <li class="grid-item" data-jkit="[show:delay=2800;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/choke-icon.jpg">
+  <img src="img/portfolio/3d/choke-icon.jpg" alt="I hope you choke sculpture thumbnail">
   <a href="3d/choke.html">
     <div class="grid-hover">
       <h1>I hope you choke</h1>
@@ -163,7 +167,7 @@
 
 <!--Engram/Digital Bath-->
 <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/bath.jpg">
+  <img src="img/portfolio/3d/bath.jpg" alt="Digital Bath/Engram installation thumbnail">
   <a href="3d/bath.html">
     <div class="grid-hover">
       <h1>Digital Bath/Engram</h1>
@@ -179,7 +183,7 @@
 
 <!--I'd never lie to you-->
 <li class="grid-item" data-jkit="[show:delay=700;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/lie.jpg">
+  <img src="img/portfolio/3d/lie.jpg" alt="I'd never lie to you sculpture thumbnail">
   <a href="3d/lie.html">
     <div class="grid-hover">
       <h1>I'd never lie to you</h1>
@@ -190,7 +194,7 @@
 
 <!--Untitled-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/untitled.jpg">
+  <img src="img/portfolio/flat/untitled.jpg" alt="Untitled (an act of war) artwork thumbnail">
   <a href="2d/untitled.html">
     <div class="grid-hover">
       <h1>Untitled (an act of war)</h1>
@@ -205,7 +209,7 @@
 
 <!--no meaning-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/post.jpg">
+  <img src="img/portfolio/flat/post.jpg" alt="Banners poster thumbnail">
   <a href="2d/banners.html">
     <div class="grid-hover">
       <h1>Banners</h1>
@@ -215,7 +219,7 @@
 
 <!--a fair warning-->
 <li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/warning.jpg">
+  <img src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
   <a href="3d/warning.html">
     <div class="grid-hover">
       <h1>A fair warning</h1>
@@ -231,7 +235,7 @@
 
 <!--Stairs-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/save.jpg">
+  <img src="img/portfolio/3d/save.jpg" alt="Red Stairs/Somebody please save us installation thumbnail">
   <a href="3d/redstairs.html">
     <div class="grid-hover">
       <h1>Red Stairs/Somebody please save us</h1>
@@ -247,7 +251,7 @@
 
 <!--Delay hasn't cost me a thing-->
 <li class="grid-item" data-jkit="[show:delay=1500;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/call.jpg">
+  <img src="img/portfolio/3d/call.jpg" alt="Delay hasn't cost me anything sculpture thumbnail">
   <a href="3d/call.html">
     <div class="grid-hover">
       <h1>Delay hasn't cost me anything</h1>
@@ -263,7 +267,7 @@
 
 <!--Nightstalker Re-Runs-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/windows.jpg">
+  <img src="img/portfolio/flat/windows.jpg" alt="Nighstalker Re-Runs on Channel 4 collage thumbnail">
   <a href="2d/stalker.html">
     <div class="grid-hover">
       <h1>Nighstalker Re-Runs on Channel 4</h1>
@@ -283,7 +287,7 @@
 
 <!--Are you ready to fly-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/fly.jpg">
+  <img src="img/portfolio/3d/fly.jpg" alt="Are you ready to fly? installation thumbnail">
   <a href="3d/fly.html">
     <div class="grid-hover">
       <h1>Are you ready to fly?</h1>
@@ -294,7 +298,7 @@
 
 <!-- The truth is, I hate to tell you-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/hate.jpg">
+  <img src="img/portfolio/flat/hate.jpg" alt="The truth is, I hate to tell you artwork thumbnail">
   <a href="2d/hate.html">
     <div class="grid-hover">
       <h1>The truth is, I hate to tell you</h1>
@@ -309,7 +313,7 @@
 
 <!--I can't tell where to begin-->
 <li class="grid-item" data-jkit="[show:delay=2500;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/party.jpg">
+  <img src="img/portfolio/3d/party.jpg" alt="I can't tell where to begin action piece thumbnail">
   <a href="3d/party.html">
     <div class="grid-hover">
       <h1>I can't tell where to begin</h1>
@@ -325,7 +329,7 @@
 
 <!--They're preparing for war -->
 <li class="grid-item" data-jkit="[show:delay=900;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/war_1.jpg">
+  <img src="img/portfolio/3d/war_1.jpg" alt="They're preparing for war installation thumbnail">
   <a href="3d/war.html">
     <div class="grid-hover">
       <h1>They're preparing for war</h1>
@@ -336,7 +340,7 @@
 
 <!--A fair warning-->
 <li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/warning.jpg">
+  <img src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
   <a href="3d/warning.html">
     <div class="grid-hover">
       <h1>A fair warning</h1>
@@ -345,6 +349,6 @@
   </a>
 </li>
 
-<!--End of main content-->
-</div>
-</ul>
+  <!--End of main content-->
+      </ul>
+  </div>

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,7 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif">
+    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>

--- a/courses.html
+++ b/courses.html
@@ -45,7 +45,7 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif">
+    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>
@@ -53,6 +53,10 @@
 
   <!--Content-->
   <div class="content">
+    <div class="text-intro">
+      <h1>Academic Portfolio</h1>
+      <p>Syllabi and assorted classroom experiments are simmering here. Check back while the dust settles.</p>
+    </div>
 
     <!--
 

--- a/css/style-responsive.css
+++ b/css/style-responsive.css
@@ -131,19 +131,6 @@
     max-width:600px;
   }
 
-  .home-sidebar{
-    display:none;
-  }
-
-  ul.header-nav{
-    width:50%;
-
-  }
-
-  header li > a{
-    padding-right: 15px;
-    padding-left: 15px;
-  }
 
 
 
@@ -203,19 +190,6 @@
     max-width:400px;
   }
 
-  .home-sidebar{
-    display:none;
-  }
-
-  ul.header-nav{
-    width:50%;
-
-  }
-
-  header li > a{
-    padding-right: 15px;
-    padding-left: 15px;
-  }
 
   .one-column, .two-column{
     width:100%;
@@ -298,10 +272,6 @@
 
   .prev-next{
     max-width:280px;
-  }
-
-  .home-sidebar{
-    display:none;
   }
 
   .one-column, .two-column{

--- a/css/style.css
+++ b/css/style.css
@@ -158,52 +158,6 @@ ul.menu-fullscreen li > a:hover{
 
 /*
 **************************
-HEADER
-**************************
-*/
-header.boxed{
-  position:fixed;
-  width:100%;
-  margin:0 auto;
-  height:80px;
-  z-index:9999;
-  display:none;
-  background:none;
-  top:0;
-  -webkit-transition: background 0.2s ease-in;
-	-moz-transition: background 0.2s ease-in;
-	-ms-transition: background 0.2s ease-in;
-	-o-transition: background 0.2s ease-in;
-	transition: background 0.2s ease-in;
-}
-
-header.boxed .header-margin{
-  width:1140px;
-  margin:0 auto;
-}
-
-header.boxed .header-margin-mini{
-  width:90%;
-  margin:0 auto;
-}
-
-
-ul.social-icon{
-  float:right;
-}
-
-ul.social-icon a{
-  float:right;
-  font-size:15px;
-  border-bottom:0;
-  color:black;
-  padding-right:0px !important;
-}
-
-ul.social-icon a:hover{
-  color:#c3c3c3;
-}
-
 .menu-index{
   position: fixed;
   right: 5%;
@@ -224,86 +178,6 @@ ul.social-icon a:hover{
 
 .menu-index i:hover{
   color:#c3c3c3;
-}
-
-ul.menu-icon{
-  float:right;
-}
-
-ul.menu-icon a{
-  float:right;
-  font-size:19px;
-  color:white;
-  padding-right:0px !important;
-}
-
-ul.menu-icon i{
-  padding:20px;
-  background:black;
-}
-
-ul.menu-icon a:hover{
-  color:#c3c3c3;
-}
-
-header a{
-  color:#000000;
-}
-
-ul.header-nav{
-  width:60%;
-  float:left;
-}
-
-header .logo > a{
-  font-size:23px;
-  font-weight:800;
-  float:left;
-  line-height:80px;
-  padding-right:40px;
-  border-bottom: 1px solid #f1f1f1;
-}
-
-header .logo > a:hover{
-  color:#c3c3c3;
-}
-
-header li{
-  text-transform:uppercase;
-  list-style-type: none; margin: 0 auto; float: left;
-}
-
-header li > a{
-  font-size:13px;
-  color:#c3c3c3;
-  padding-right:25px;
-  padding-left:25px;
-  font-weight:800;
-  line-height:80px;
-  display:inline-block;
-  border-bottom:0;
-}
-
-header li > a:hover{
-  color:#000000;
-}
-
-header li > a #active{
-  color:#000000;
-}
-
-header li ul{
-  overflow: hidden; display: none; background: #f9f9f9; z-index:20;
-}
-
-header li ul li a{
-  line-height:50px;
-  padding-left:30px;
-  width:260px;
-}
-
-header li:hover ul{
-  position: absolute; padding: 0; display: block; width: 260px;
 }
 
 
@@ -426,32 +300,6 @@ CONTENT
             50% { opacity:0; }
             100% { opacity:1; }
         }
-
-/*
-**************************
-HOME SIDEBAR
-**************************
-*/
-
-.home-sidebar{
-  top:0;
-  position:absolute;
-  width:33.3333%;
-  right:0;
-  height:100%;
-  background:#f4f4f4;
-  z-index:9;
-  overflow:hidden;
-  background-size:100%;
-}
-
-.parallax{
-  position:absolute;
-}
-
-.parallax-option{
-  position:absolute; width:100%; height:100%;
-}
 
 /*
 **************************

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif">
+    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>
@@ -73,6 +73,7 @@
     <div class="text-intro" id="site-type">
       <h1>B.Severns</h1>
       <p><del>An anthonology of dead ends &amp; bad ideas</del></p>
+      <p class="tagline">Click into the academic or studio worlds below; hover for hints, dive for details.</p>
       <h1 class="typewrite"><span></span></h1>
     </div>
 
@@ -81,24 +82,24 @@
     <!--Portfolio grid-->
     <ul class="portfolio-grid">
         <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-      <img src="img/icon.png"> <!--To be fixed -->
+      <img src="img/icon.png" alt="placeholder cube icon"> <!--To be fixed -->
           <a href="courses.html">
             <div class="grid-hover">
                 <h2>Academic Portfolio</h2>
                 <p>Course syllabi and other materials</p>
               </div>
-              </a<
-            </li>
+          </a>
+        </li>
 
             <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-          <img src="img/icon.png"> <!--To be fixed -->
+            <img src="img/icon.png" alt="placeholder cube icon"> <!--To be fixed -->
               <a href="art.html">
                 <div class="grid-hover">
                     <h2>Studio Portfolio</h2>
                     <p>Media and experiments with varied documentation</p>
                   </div>
-                  </a<
-                </li>
+              </a>
+            </li>
 
             <!--a generative p5.js thing here-->
 


### PR DESCRIPTION
## Summary
- expand README with site structure and quick dev tips
- add banner and thumbnail `alt` text across main pages
- trim unused header and sidebar styles for lighter CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fb35c19c83259914b2b051023d79