### PR TITLE
wire up art page scripts and trim preloader lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ No build pipeline here. Spin up a bare-bones server with `python3 -m http.server
 Key images now carry `alt` text to make the site friendlier to screen readers. Keep that vibe if you add more work.
 
 PRs, issues, or weird ideas welcome. Keep it noisy and accessible.
+
+## Speed hacks
+The art gallery page now loads like it's had three espressos. Images lazy-load so your browser isn't choking on megabytes it hasn't even looked at yet, and the preloader ducks out after half a second instead of staring back at you forever.

--- a/art.html
+++ b/art.html
@@ -45,7 +45,7 @@
 
   <!--Header image/menu-->
   <header id="fullscreen">
-    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
+    <img loading="lazy" src="img/front/banner.gif" alt="glitchy rainbow banner">
     <div class="menu-index" id="button">
       <i class="fa fa-th"></i>
     </div>
@@ -60,7 +60,7 @@
     <ul class="portfolio-grid">
 
 <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/truth.jpg" alt="We hold these truths artwork thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/truth.jpg" alt="We hold these truths artwork thumbnail">
   <a href="3d/truth.html">
     <div class="grid-hover">
       <h1>We hold these truths</h1>
@@ -87,7 +87,7 @@
 
 <!--Construct/Obstruct-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="3d/full3d/conob.jpeg" alt="Construct//Obstruct artwork thumbnail">
+  <img loading="lazy" src="3d/full3d/conob.jpeg" alt="Construct//Obstruct artwork thumbnail">
   <a href="3d/con.html">
     <div class="grid-hover">
       <h1>Construct//Obstruct</h1>
@@ -104,7 +104,7 @@
 
 <!--context-->
 <li class="grid-item" data-jkit="[show:delay=3750;speed=500;animation=fade]">
-  <img src="img/front/context.jpg" alt="CONTEXT sketchbook thumbnail">
+  <img loading="lazy" src="img/front/context.jpg" alt="CONTEXT sketchbook thumbnail">
   <a href="http://bseverns.tumblr.com" target="_blank">
     <div class="grid-hover">
       <h1>CONTEXT</h1>
@@ -120,7 +120,7 @@
 
 <!--Tonal Dissonance-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/hook.jpg" alt="Tonal dissonance artwork thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/hook.jpg" alt="Tonal dissonance artwork thumbnail">
   <a href="3d/redstairs.html">
     <div class="grid-hover">
       <h1>Tonal dissonance</h1>
@@ -136,7 +136,7 @@
 
 <!--Jackass-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/ex1.jpg" alt="Jackass artwork thumbnail">
+  <img loading="lazy" src="img/portfolio/flat/ex1.jpg" alt="Jackass artwork thumbnail">
   <a href="2d/divine.html">
     <div class="grid-hover">
       <h1>Jackass(Experiments in rendering the divine)</h1>
@@ -146,7 +146,7 @@
 
 <!--I hope you choke-->
 <li class="grid-item" data-jkit="[show:delay=2800;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/choke-icon.jpg" alt="I hope you choke sculpture thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/choke-icon.jpg" alt="I hope you choke sculpture thumbnail">
   <a href="3d/choke.html">
     <div class="grid-hover">
       <h1>I hope you choke</h1>
@@ -167,7 +167,7 @@
 
 <!--Engram/Digital Bath-->
 <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/bath.jpg" alt="Digital Bath/Engram installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/bath.jpg" alt="Digital Bath/Engram installation thumbnail">
   <a href="3d/bath.html">
     <div class="grid-hover">
       <h1>Digital Bath/Engram</h1>
@@ -183,7 +183,7 @@
 
 <!--I'd never lie to you-->
 <li class="grid-item" data-jkit="[show:delay=700;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/lie.jpg" alt="I'd never lie to you sculpture thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/lie.jpg" alt="I'd never lie to you sculpture thumbnail">
   <a href="3d/lie.html">
     <div class="grid-hover">
       <h1>I'd never lie to you</h1>
@@ -194,7 +194,7 @@
 
 <!--Untitled-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/untitled.jpg" alt="Untitled (an act of war) artwork thumbnail">
+  <img loading="lazy" src="img/portfolio/flat/untitled.jpg" alt="Untitled (an act of war) artwork thumbnail">
   <a href="2d/untitled.html">
     <div class="grid-hover">
       <h1>Untitled (an act of war)</h1>
@@ -209,7 +209,7 @@
 
 <!--no meaning-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/post.jpg" alt="Banners poster thumbnail">
+  <img loading="lazy" src="img/portfolio/flat/post.jpg" alt="Banners poster thumbnail">
   <a href="2d/banners.html">
     <div class="grid-hover">
       <h1>Banners</h1>
@@ -219,7 +219,7 @@
 
 <!--a fair warning-->
 <li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
   <a href="3d/warning.html">
     <div class="grid-hover">
       <h1>A fair warning</h1>
@@ -235,7 +235,7 @@
 
 <!--Stairs-->
 <li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/save.jpg" alt="Red Stairs/Somebody please save us installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/save.jpg" alt="Red Stairs/Somebody please save us installation thumbnail">
   <a href="3d/redstairs.html">
     <div class="grid-hover">
       <h1>Red Stairs/Somebody please save us</h1>
@@ -251,7 +251,7 @@
 
 <!--Delay hasn't cost me a thing-->
 <li class="grid-item" data-jkit="[show:delay=1500;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/call.jpg" alt="Delay hasn't cost me anything sculpture thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/call.jpg" alt="Delay hasn't cost me anything sculpture thumbnail">
   <a href="3d/call.html">
     <div class="grid-hover">
       <h1>Delay hasn't cost me anything</h1>
@@ -267,7 +267,7 @@
 
 <!--Nightstalker Re-Runs-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/windows.jpg" alt="Nighstalker Re-Runs on Channel 4 collage thumbnail">
+  <img loading="lazy" src="img/portfolio/flat/windows.jpg" alt="Nighstalker Re-Runs on Channel 4 collage thumbnail">
   <a href="2d/stalker.html">
     <div class="grid-hover">
       <h1>Nighstalker Re-Runs on Channel 4</h1>
@@ -287,7 +287,7 @@
 
 <!--Are you ready to fly-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/fly.jpg" alt="Are you ready to fly? installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/fly.jpg" alt="Are you ready to fly? installation thumbnail">
   <a href="3d/fly.html">
     <div class="grid-hover">
       <h1>Are you ready to fly?</h1>
@@ -298,7 +298,7 @@
 
 <!-- The truth is, I hate to tell you-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img src="img/portfolio/flat/hate.jpg" alt="The truth is, I hate to tell you artwork thumbnail">
+  <img loading="lazy" src="img/portfolio/flat/hate.jpg" alt="The truth is, I hate to tell you artwork thumbnail">
   <a href="2d/hate.html">
     <div class="grid-hover">
       <h1>The truth is, I hate to tell you</h1>
@@ -313,7 +313,7 @@
 
 <!--I can't tell where to begin-->
 <li class="grid-item" data-jkit="[show:delay=2500;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/party.jpg" alt="I can't tell where to begin action piece thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/party.jpg" alt="I can't tell where to begin action piece thumbnail">
   <a href="3d/party.html">
     <div class="grid-hover">
       <h1>I can't tell where to begin</h1>
@@ -329,7 +329,7 @@
 
 <!--They're preparing for war -->
 <li class="grid-item" data-jkit="[show:delay=900;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/war_1.jpg" alt="They're preparing for war installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/war_1.jpg" alt="They're preparing for war installation thumbnail">
   <a href="3d/war.html">
     <div class="grid-hover">
       <h1>They're preparing for war</h1>
@@ -340,7 +340,7 @@
 
 <!--A fair warning-->
 <li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
+  <img loading="lazy" src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
   <a href="3d/warning.html">
     <div class="grid-hover">
       <h1>A fair warning</h1>
@@ -352,3 +352,32 @@
   <!--End of main content-->
       </ul>
   </div>
+  <!--Footer-->
+  <footer>
+    <div class="footer-margin">
+      <div class="social-footer">
+        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
+      </div>
+      <div class="copyright">© Copyright 2005-2024 BSeverns.com. CC SA 4.0</div>
+    </div>
+  </footer>
+</body>
+
+  <!--jquery things-->
+  <script src="js/jquery.min.js"></script>
+  <script src="js/jquery.easing.min.js"></script>
+  <script src="js/modernizr.custom.42534.js" type="text/javascript"></script>
+  <script src="js/jquery.waitforimages.js" type="text/javascript"></script>
+  <script src="js/typed.js" type="text/javascript"></script>
+  <script src="js/masonry.pkgd.min.js" type="text/javascript"></script>
+  <script src="js/imagesloaded.pkgd.min.js" type="text/javascript"></script>
+  <script src="js/jquery.jkit.1.2.16.min.js"></script>
+  <script src="js/script.js" type="text/javascript"></script>
+
+<script>
+  $('#button, #buttons').on('click', function() {
+    $(".opacity-nav").fadeToggle("slow", "linear"); /* Animation complete.*/
+  });
+</script>
+
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -237,7 +237,7 @@ function showPreloader() {
 }
 
 function hidePreloader() {
-  $(".preloader").delay(2000).fadeOut("slow");
+  $(".preloader").delay(500).fadeOut("slow");
 }
 
 


### PR DESCRIPTION
## Summary
- Lazy-load every art page image so browsers aren't slamming the throttle on first paint
- Restore footer + script imports on `art.html` to actually hide the preloader
- Drop preloader fade delay from 2s to 0.5s for a snappier entrance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c603862aa08325ba690ba4cdcf46ff