### PR TITLE
Switch external assets to HTTPS

### DIFF
--- a/2d/banners.html
+++ b/2d/banners.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -61,7 +61,7 @@
 	          </div>
 		          <div class="two-column">
 		            <p>“There are things like reflecting pools, and images, an infinite reference from one to the other, but no longer a source, a spring. There is no longer any simple origin. For what is reflected it split in itself and not only as an addition to itself of its image. The reflection, the image, the double, splits what it doubles. The origin of the speculation becomes a difference. What can look at itself is not one; and the law of the addition of the origin to its representation, or the thing to its image, is that one plus one makes at least three.”</p></br>
-                <p><a href="http://www.pressherald.com/2013/05/19/meca-show-portends-good-things-for-meart_2013-05-19/">We all have our reasons for doing things</a></p>
+                <p><a href="https://www.pressherald.com/2013/05/19/meca-show-portends-good-things-for-meart_2013-05-19/">We all have our reasons for doing things</a></p>
 		          </div>
                 <div class="clear"></div>
 				        <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
@@ -75,8 +75,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/2d/divine.html
+++ b/2d/divine.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -75,8 +75,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/2d/hate.html
+++ b/2d/hate.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -75,8 +75,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/2d/stalker.html
+++ b/2d/stalker.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -79,8 +79,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/2d/untitled.html
+++ b/2d/untitled.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/bath.html
+++ b/3d/bath.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/call.html
+++ b/3d/call.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -72,8 +72,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/choke.html
+++ b/3d/choke.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/con.html
+++ b/3d/con.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -72,8 +72,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/fly.html
+++ b/3d/fly.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -79,8 +79,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/lie.html
+++ b/3d/lie.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -74,8 +74,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/party.html
+++ b/3d/party.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/redstairs.html
+++ b/3d/redstairs.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -74,8 +74,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/truth.html
+++ b/3d/truth.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/war.html
+++ b/3d/war.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -73,8 +73,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/3d/warning.html
+++ b/3d/warning.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
@@ -75,8 +75,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -110,8 +110,8 @@
       <div class="footer-margin">
         <div class="social-footer">
           <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-          <!--<a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-          <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+          <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
+          <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
         </div>
         <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
       </div>

--- a/art.html
+++ b/art.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -105,7 +105,7 @@
 <!--context-->
 <li class="grid-item" data-jkit="[show:delay=3750;speed=500;animation=fade]">
   <img loading="lazy" src="img/front/context.jpg" alt="CONTEXT sketchbook thumbnail">
-  <a href="http://bseverns.tumblr.com" target="_blank">
+  <a href="https://bseverns.tumblr.com" target="_blank">
     <div class="grid-hover">
       <h1>CONTEXT</h1>
       <p>Sketch, Catalog, Feedback</p>
@@ -356,7 +356,7 @@
   <footer>
     <div class="footer-margin">
       <div class="social-footer">
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
       </div>
       <div class="copyright">© Copyright 2005-2024 BSeverns.com. CC SA 4.0</div>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -87,8 +87,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <!--<a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+        <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
       </div>
       <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
     </div>

--- a/courses.html
+++ b/courses.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -87,8 +87,8 @@ NOTHING HERE BOSS
         <div class="footer-margin">
           <div class="social-footer">
             <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-            <!--<a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-            <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
+            <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
+            <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
             <p>Or you can contact me at severns 3 {at} {a mail service from daddy-Goog}</p>
           </div>
           <div class="copyright">© Copyright 2005-2022 BSeverns.com. All Rights Reserved.</div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -111,7 +111,7 @@
   <footer>
     <div class="footer-margin">
       <div class="social-footer">
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
         <!--Github &&reddit? && video sharing && ??? -->
       </div>
       <div class="copyright">© Copyright 2005-2024 BSeverns.com. CC SA 4.0</div>

--- a/text/text_program1.html
+++ b/text/text_program1.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <!--
   <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js"></script>
   <script src="js/tunnelSketch.js"></script>
@@ -69,8 +69,8 @@
     <div class="footer-margin">
       <div class="social-footer">
         <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <!--<a href="http://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-        <a href="http://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
+        <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
+        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
         <p>Or you can contact me at severns 3 {at} {a mail service from daddy-Goog}</p>
       </div>
       <div class="copyright">© Copyright 2005-2022 BSeverns.com. All Rights Reserved.</div>


### PR DESCRIPTION
## Summary
- serve Font Awesome over secure HTTPS instead of the old `http` CDN
- flip social and reference links to `https://` so browsers stop moaning about mixed content

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_68c60652fdd883259f71ad5c358021ad