### PR TITLE
Add unlisted Critical Digital Studies sampler page with linter

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,3 +9,7 @@
 <meta property="og:image" content="{{ page.og_image | default: '/assets/og-default.png' | relative_url }}">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="{{ '/assets/site.css' | relative_url }}">
+
+{% if page.noindex %}
+<meta name="robots" content="noindex, noarchive, noimageindex">
+{% endif %}

--- a/assets/docs/README.md
+++ b/assets/docs/README.md
@@ -1,0 +1,4 @@
+# PDF stash
+
+Park your actual sampler PDF here as `Severns_CriticalDigitalStudies_Sampler.pdf`.
+This text file exists so the directory sticks around without shipping binaries.

--- a/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf
+++ b/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf
@@ -1,0 +1,1 @@
+TODO: Replace with full Critical Digital Studies sampler PDF.

--- a/assets/images/cds/README.md
+++ b/assets/images/cds/README.md
@@ -1,0 +1,4 @@
+# Critical Digital Studies sampler assets
+
+These `.png`/`.jpg` files are text-only placeholders because the repo stays binary-free.
+Swap in your real images with the same filenames when it's showtime.

--- a/assets/images/cds/ds200412-still.jpg
+++ b/assets/images/cds/ds200412-still.jpg
@@ -1,0 +1,1 @@
+TODO: Replace with JPG still from DEAD SKY (DS200412).

--- a/assets/images/cds/faceTimes-consent.png
+++ b/assets/images/cds/faceTimes-consent.png
@@ -1,0 +1,1 @@
+TODO: Replace with PNG showing the faceTimes consent gate.

--- a/assets/images/cds/glitch-geometry-still.jpg
+++ b/assets/images/cds/glitch-geometry-still.jpg
@@ -1,0 +1,1 @@
+TODO: Replace with JPG still from the Glitch Geometry instrument.

--- a/assets/images/cds/mn42-panel.jpg
+++ b/assets/images/cds/mn42-panel.jpg
@@ -1,0 +1,1 @@
+TODO: Replace with JPG of the MOARkNOBS-42 panel top-down.

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: "Critical Digital Studies — Sampler (Unlisted)"
+permalink: /critical-digital-studies-sampler/
+seo_description: "Unlisted sampler of practice-based work in critical digital studies"
+sitemap: false
+noindex: true
+---
+
+# Critical Digital Studies — Sampler (Unlisted)
+
+> This unlisted page collects four practice-based projects that pair critical inquiry with hands-on digital practice (*playful rigor*: build → perform → document → iterate). Please access via direct link.
+
+<div class="cards">
+
+<article class="card">
+  <img src="/assets/images/cds/faceTimes-consent.png" alt="faceTimes consent gate (detection-only, opt-in)">
+  <h3>faceTimes — Consent-Forward Vision Station</h3>
+  <p><strong>Method:</strong> On-device detection-only; explicit opt-in; delete-now; no network calls or identification. Documentation (README, PRIVACY/ETHICS, assumption ledger) treated as research output.</p>
+  <ul>
+    <li>Classroom demo & public kiosk contexts</li>
+    <li>Detection overlay with visible status + erase</li>
+    <li>System: webcam → local detector → ephemeral buffer → user action</li>
+  </ul>
+  <p><a href="https://github.com/bseverns/faceTimes">Repo</a> • <a href="#" aria-disabled="true">Vimeo clip (add link)</a></p>
+</article>
+
+<article class="card">
+  <img src="/assets/images/cds/mn42-panel.jpg" alt="MOARkNOBS-42 panel top-down">
+  <h3>MOARkNOBS-42 — Open-Source Microcontroller MIDI Controller</h3>
+  <p><strong>Method:</strong> Reproducible hardware+firmware; parameter mapping as inquiry into authorship/control; latency characterized and documented.</p>
+  <ul>
+    <li>Teensy-based instrument + teaching platform</li>
+    <li>Docs: BOM, wiring, parameter map, methods & ethics</li>
+  </ul>
+  <p><a href="https://github.com/bseverns/MOARkNOBS-42">Repo</a> • <a href="#" aria-disabled="true">Demo video (optional)</a></p>
+</article>
+
+<article class="card">
+  <img src="/assets/images/cds/glitch-geometry-still.jpg" alt="Audio-driven generative geometry still">
+  <h3>Glitch Geometry — Audio→Form Instrument</h3>
+  <p><strong>Method:</strong> Live translation of signal features into geometry; pipeline choices (feature extraction, modulation, rendering) made legible as aesthetic/ethical decisions.</p>
+  <ul>
+    <li>Signal in → features → geometry modulation → render</li>
+    <li>Documented, tunable pipeline for teaching/critique</li>
+  </ul>
+  <p><a href="#" aria-disabled="true">Vimeo excerpt (add link)</a></p>
+</article>
+
+<article class="card">
+  <img src="/assets/images/cds/ds200412-still.jpg" alt="DEAD SKY rural pursuit still">
+  <h3>DEAD SKY — Vision & Motion Grammar Studies</h3>
+  <p><strong>Method:</strong> Two short studies—rural pursuit (DS200412) and wheel-mounted POV (DS200801)—probing surveillance logics, attention, and embodied capture for a larger film.</p>
+  <ul>
+    <li>November light, long-lens pursuit grammar</li>
+    <li>Mechanical vision and cyclic motion (wheel POV)</li>
+  </ul>
+  <p><a href="https://vimeo.com/user2746012" target="_blank" rel="noopener">Vimeo profile (clip timecodes TBD)</a></p>
+</article>
+
+</div>
+
+<hr>
+
+<p><a href="/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf">Download PDF sampler</a> (placeholder) • This page is <em>unlisted</em> and marked <code>noindex</code>.</p>
+
+<style>
+.cards { display:grid; gap:1.25rem; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
+.card { border:1px solid #ddd; padding:1rem; border-radius:12px; }
+.card img { max-width:100%; height:auto; border-radius:8px; }
+.card h3 { margin:.6rem 0 .35rem; }
+.card ul { margin:.25rem 0 .5rem 1.2rem; }
+</style>
+

--- a/tools/lint_hidden_page.py
+++ b/tools/lint_hidden_page.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import os, sys, re, json
+
+ROOT = os.path.dirname(os.path.abspath(__file__)) + "/.."
+page = os.path.join(ROOT, "critical-digital-studies-sampler", "index.md")
+issues = []
+
+if not os.path.exists(page):
+    issues.append("Page missing: critical-digital-studies-sampler/index.md")
+
+# Check front matter flags
+fm = ""
+with open(page, "r", encoding="utf-8") as f:
+    txt = f.read()
+m = re.search(r"^---(.*?)---", txt, re.S | re.M)
+if m:
+    fm = m.group(1)
+else:
+    issues.append("No YAML front matter detected.")
+
+def has(k, v=None):
+    if not fm: return False
+    if v is None:
+        return re.search(rf"^{k}\s*:\s*", fm, re.M) is not None
+    return re.search(rf"^{k}\s*:\s*{re.escape(str(v))}\s*$", fm, re.M) is not None
+
+if not has("noindex", "true"):
+    issues.append("Front matter should include: noindex: true")
+if not has("sitemap", "false"):
+    issues.append("Front matter should include: sitemap: false")
+
+# Check that nav doesn't link it (if navigation data exists)
+nav_yml = os.path.join(ROOT, "_data", "navigation.yml")
+if os.path.exists(nav_yml):
+    with open(nav_yml, "r", encoding="utf-8") as f:
+        nav = f.read()
+    if "critical-digital-studies-sampler" in nav:
+        issues.append("Navigation contains a link to the hidden page; remove it from _data/navigation.yml")
+
+# Check assets existence
+assets = [
+    "assets/images/cds/faceTimes-consent.png",
+    "assets/images/cds/mn42-panel.jpg",
+    "assets/images/cds/glitch-geometry-still.jpg",
+    "assets/images/cds/ds200412-still.jpg",
+    "assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf"
+]
+for a in assets:
+    if not os.path.exists(os.path.join(ROOT, a)):
+        issues.append(f"Missing asset placeholder: {a}")
+
+if issues:
+    print("\nHidden page checks: FAIL\n- " + "\n- ".join(issues))
+    sys.exit(1)
+else:
+    print("Hidden page checks: PASS")


### PR DESCRIPTION
## Summary
- Add hidden `/critical-digital-studies-sampler/` page with four project cards and placeholders for images/PDF.
- Append `noindex` meta logic in head include so bots ignore this page.
- Drop a small Python linter to verify noindex, sitemap:false, nav exclusion, and placeholder assets.
- Replace binary image/PDF placeholders with text TODO files to keep the repo binary-free.

## Testing
- `python3 tools/lint_hidden_page.py`
- `rg "critical-digital-studies-sampler" -n`
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c78a2789a08325889ed25ead8c4883