### PR TITLE
Add structured sampler page with placeholders and linter

### DIFF
--- a/assets/docs/README.md
+++ b/assets/docs/README.md
@@ -1,4 +1,11 @@
 # PDF stash
 
-Park your actual sampler PDF here as `Severns_CriticalDigitalStudies_Sampler.pdf`.
-This text file exists so the directory sticks around without shipping binaries.
+This folder exists solely to host the sampler PDF without fattening the repo.
+Right now it ships a one-page "coming soon" file so builds don't choke.
+
+## Swap-in ritual
+1. Render your real sampler PDF.
+2. Overwrite `Severns_CriticalDigitalStudies_Sampler.pdf`.
+3. Run `python tools/lint_sampler.py` to make sure the linter is still happy.
+
+Keeping this directory under version control lets future students audit change over time—no ghost docs.

--- a/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf
+++ b/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf
@@ -1,1 +1,21 @@
-TODO: Replace with full Critical Digital Studies sampler PDF.
+%PDF-1.1
+1 0 obj<<>>endobj
+2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>endobj
+3 0 obj<< /Type /Page /Parent 2 0 R /Resources <<>> /Contents 4 0 R >>endobj
+4 0 obj<< /Length 44 >>stream
+BT /F1 24 Tf 100 700 Td (Coming soon) Tj ET
+endstream
+endobj
+5 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000031 00000 n 
+0000000092 00000 n 
+0000000191 00000 n 
+0000000276 00000 n 
+trailer<< /Size 6 /Root 5 0 R >>
+startxref
+343
+%%EOF

--- a/assets/images/cds/README.md
+++ b/assets/images/cds/README.md
@@ -1,4 +1,15 @@
 # Critical Digital Studies sampler assets
 
-These `.png`/`.jpg` files are text-only placeholders because the repo stays binary-free.
-Swap in your real images with the same filenames when it's showtime.
+These slots boot with plain-text `.svg` stand-ins so the repo ships light and review-friendly.
+Drop in your own visuals—stick to the same filenames so the card markup doesn't blink.
+
+## Why placeholders?
+- Keeps pull requests diffable without dragging binaries through git history.
+- Lets the linter scream if a required image goes missing.
+
+## Swapping them out
+1. Export your real image at `1200×675`.
+2. Overwrite the matching `.svg` file here with your asset (keep the name).
+3. Commit, run `python tools/lint_sampler.py`, and roll on.
+
+Yes, it's a little bare-bones, but that's the point—we're shipping scaffolding, not secrets.

--- a/assets/images/cds/ds200412-still.jpg
+++ b/assets/images/cds/ds200412-still.jpg
@@ -1,1 +1,0 @@
-TODO: Replace with JPG still from DEAD SKY (DS200412).

--- a/assets/images/cds/ds200412-still.svg
+++ b/assets/images/cds/ds200412-still.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — DEAD SKY DS200412 still</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — DEAD SKY DS200412 still</text>
+</svg>

--- a/assets/images/cds/faceTimes-consent.png
+++ b/assets/images/cds/faceTimes-consent.png
@@ -1,1 +1,0 @@
-TODO: Replace with PNG showing the faceTimes consent gate.

--- a/assets/images/cds/faceTimes-consent.svg
+++ b/assets/images/cds/faceTimes-consent.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — faceTimes consent</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — faceTimes consent</text>
+</svg>

--- a/assets/images/cds/glitch-geometry-still.jpg
+++ b/assets/images/cds/glitch-geometry-still.jpg
@@ -1,1 +1,0 @@
-TODO: Replace with JPG still from the Glitch Geometry instrument.

--- a/assets/images/cds/glitch-geometry-still.svg
+++ b/assets/images/cds/glitch-geometry-still.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — Glitch Geometry still</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — Glitch Geometry still</text>
+</svg>

--- a/assets/images/cds/mcad-media2-mtn.svg
+++ b/assets/images/cds/mcad-media2-mtn.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — MCAD Media 2 MTN broadcast</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — MCAD Media 2 MTN broadcast</text>
+</svg>

--- a/assets/images/cds/mn42-panel.jpg
+++ b/assets/images/cds/mn42-panel.jpg
@@ -1,1 +1,0 @@
-TODO: Replace with JPG of the MOARkNOBS-42 panel top-down.

--- a/assets/images/cds/mn42-panel.svg
+++ b/assets/images/cds/mn42-panel.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — MOARkNOBS-42 panel</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — MOARkNOBS-42 panel</text>
+</svg>

--- a/assets/images/cds/spectacle-mediafast.svg
+++ b/assets/images/cds/spectacle-mediafast.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675">
+  <title>PLACEHOLDER — Spectacle/Media Fast</title>
+  <rect width="1200" height="675" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#555">PLACEHOLDER — Spectacle / Media Fast</text>
+</svg>

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -2,21 +2,26 @@
 layout: default
 title: "Critical Digital Studies — Sampler (Unlisted)"
 permalink: /critical-digital-studies-sampler/
-seo_description: "Unlisted sampler of practice-based work in critical digital studies"
+seo_description: "Unlisted sampler of practice-based work in critical digital studies by Ben Severns"
 sitemap: false
 noindex: true
+updated: "2025-09-14"
 ---
+
+<!-- Ghost page — keep it off the nav and out of search. Swappable assets live in /assets/images/cds/ and /assets/docs/. -->
 
 # Critical Digital Studies — Sampler (Unlisted)
 
-> This unlisted page collects four practice-based projects that pair critical inquiry with hands-on digital practice (*playful rigor*: build → perform → document → iterate). Please access via direct link.
+I pair critical inquiry with hands-on digital practice — *playful rigor*: **build → perform → document → iterate**. Working **systems-first**, I map technical / operational / ethical layers and translate them into scaffolds, demos, and documentation others can use, audit, and extend. This unlisted page gathers practice-based work across consent-forward vision, open hardware, audio→form pipelines, and film/vision grammar.
 
 <div class="cards">
 
+<!-- CARD 1 -->
 <article class="card">
-  <img src="/assets/images/cds/faceTimes-consent.png" alt="faceTimes consent gate (detection-only, opt-in)">
+  <img src="/assets/images/cds/faceTimes-consent.svg" alt="faceTimes consent screen showing detection-only, opt-in language and a visible delete-now action">
   <h3>faceTimes — Consent-Forward Vision Station</h3>
-  <p><strong>Method:</strong> On-device detection-only; explicit opt-in; delete-now; no network calls or identification. Documentation (README, PRIVACY/ETHICS, assumption ledger) treated as research output.</p>
+  <p>On-device, <strong>detection-only</strong> pipeline with explicit opt-in and delete-now controls. No identification, no network calls, and no storage without consent. Interface copy foregrounds agency before computation; documentation (README, PRIVACY/ETHICS, assumption ledger) is treated as research output.</p>
+  <h4>Methods & Ethics</h4>
   <ul>
     <li>Classroom demo & public kiosk contexts</li>
     <li>Detection overlay with visible status + erase</li>
@@ -25,50 +30,92 @@ noindex: true
   <p><a href="https://github.com/bseverns/faceTimes">Repo</a> • <a href="#" aria-disabled="true">Vimeo clip (add link)</a></p>
 </article>
 
+<!-- CARD 2 -->
 <article class="card">
-  <img src="/assets/images/cds/mn42-panel.jpg" alt="MOARkNOBS-42 panel top-down">
-  <h3>MOARkNOBS-42 — Open-Source Microcontroller MIDI Controller</h3>
-  <p><strong>Method:</strong> Reproducible hardware+firmware; parameter mapping as inquiry into authorship/control; latency characterized and documented.</p>
+  <img src="/assets/images/cds/mn42-panel.svg" alt="MOARkNOBS-42 panel top-down with labeled controls">
+  <h3>MOARkNOBS-42 — open-source microcontroller MIDI controller</h3>
+  <p>Reproducible hardware + firmware used as both instrument and teaching platform. Parameter mapping functions as an inquiry into authorship and control; latency is characterized and documented so performance claims are auditable and extendable.</p>
+  <h4>Methods & Ethics</h4>
   <ul>
-    <li>Teensy-based instrument + teaching platform</li>
-    <li>Docs: BOM, wiring, parameter map, methods & ethics</li>
+    <li>Teensy-based instrument + teaching rig</li>
+    <li>Complete docs: BOM, wiring, parameter map</li>
+    <li>Measurement folded into practice (latency notes)</li>
   </ul>
   <p><a href="https://github.com/bseverns/MOARkNOBS-42">Repo</a> • <a href="#" aria-disabled="true">Demo video (optional)</a></p>
 </article>
 
+<!-- CARD 3 -->
 <article class="card">
-  <img src="/assets/images/cds/glitch-geometry-still.jpg" alt="Audio-driven generative geometry still">
+  <img src="/assets/images/cds/glitch-geometry-still.svg" alt="Generative geometry frame driven by live audio features">
   <h3>Glitch Geometry — Audio→Form Instrument</h3>
-  <p><strong>Method:</strong> Live translation of signal features into geometry; pipeline choices (feature extraction, modulation, rendering) made legible as aesthetic/ethical decisions.</p>
+  <p>Live translation of signal features into geometry; pipeline choices (feature extraction, modulation, rendering) are made legible as aesthetic and ethical decisions. The system is tunable and documented for both teaching and critique.</p>
+  <h4>Methods & Ethics</h4>
   <ul>
     <li>Signal in → features → geometry modulation → render</li>
-    <li>Documented, tunable pipeline for teaching/critique</li>
+    <li>Transparent, documented pipeline for reproducibility</li>
+    <li>Designed for classroom demos and public performance</li>
   </ul>
   <p><a href="#" aria-disabled="true">Vimeo excerpt (add link)</a></p>
 </article>
 
+<!-- CARD 4 -->
 <article class="card">
-  <img src="/assets/images/cds/ds200412-still.jpg" alt="DEAD SKY rural pursuit still">
+  <img src="/assets/images/cds/ds200412-still.svg" alt="Dead Sky rural pursuit still, a lone figure on a November road">
   <h3>DEAD SKY — Vision & Motion Grammar Studies</h3>
-  <p><strong>Method:</strong> Two short studies—rural pursuit (DS200412) and wheel-mounted POV (DS200801)—probing surveillance logics, attention, and embodied capture for a larger film.</p>
+  <p>Two short studies — rural pursuit (DS200412) and wheel-mounted POV (DS200801) — probing surveillance logics, attention, and embodied capture toward a larger film project. Tests “pursuit grammar” and mechanical vision’s entrainment.</p>
+  <h4>Methods & Ethics</h4>
   <ul>
-    <li>November light, long-lens pursuit grammar</li>
-    <li>Mechanical vision and cyclic motion (wheel POV)</li>
+    <li>November light, long-lens compression (pursuit grammar)</li>
+    <li>Wheel POV: cyclic motion & peripheral smear</li>
+    <li>Consent & site plans for actors / bystanders</li>
   </ul>
-  <p><a href="https://vimeo.com/user2746012" target="_blank" rel="noopener">Vimeo profile (clip timecodes TBD)</a></p>
+  <p><a href="https://vimeo.com/user2746012">Vimeo profile</a> (clip timecodes TBD)</p>
 </article>
+
+<!-- OPTIONAL SLOTS (uncomment and fill as you add) -->
+<!--
+<article class="card">
+  <img src="/assets/images/cds/spectacle-mediafast.svg" alt="Prompt card and public intervention still for Spectacle / Media Fast">
+  <h3>Spectacle / Media Fast — Critical Pedagogy Interventions</h3>
+  <p>Paired interventions that make media power felt: a “Spectacle” action-lecture moves critique into public space; a structured “Media Fast” maps sensory shifts and agency before reflective media making. Designed as public method; prompts and reflections are the artifacts.</p>
+  <h4>Methods & Ethics</h4>
+  <ul>
+    <li>Transparent prompts; bystander consent & respect</li>
+    <li>Reflection before publication; no IDs without release</li>
+    <li>Documentation pack (brief, roles, reflection prompts)</li>
+  </ul>
+  <p><a href="#" aria-disabled="true">Brief</a> • <a href="#" aria-disabled="true">Reflection template</a></p>
+</article>
+
+<article class="card">
+  <img src="/assets/images/cds/mcad-media2-mtn.svg" alt="MCAD Media 2: public access broadcast production still">
+  <h3>MCAD Media 2 — MTN Public Access Broadcast</h3>
+  <p>Studio-seminar culminating in a 28.5-minute MTN broadcast planned, produced, and edited by students. The artifact is civic-facing media formed by calendars, critique gates, and documentation standards for longevity.</p>
+  <h4>Methods & Ethics</h4>
+  <ul>
+    <li>Roles & calendars; consent and authorship checkpoints</li>
+    <li>Deliverables: broadcast master + process docs</li>
+    <li>Public exhibition as peer review</li>
+  </ul>
+  <p><a href="#" aria-disabled="true">Episode link</a> • <a href="#" aria-disabled="true">Production calendar</a></p>
+</article>
+-->
 
 </div>
 
 <hr>
 
-<p><a href="/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf">Download PDF sampler</a> (placeholder) • This page is <em>unlisted</em> and marked <code>noindex</code>.</p>
+<p><a href="/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf">Download PDF sampler</a> (placeholder) • This page is <em>unlisted</em> and marked <code>noindex</code>. Updated: {{ page.updated }}.</p>
 
 <style>
 .cards { display:grid; gap:1.25rem; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
-.card { border:1px solid #ddd; padding:1rem; border-radius:12px; }
+.card { border:1px solid #ddd; padding:1rem; border-radius:12px; background:#fff; }
 .card img { max-width:100%; height:auto; border-radius:8px; }
 .card h3 { margin:.6rem 0 .35rem; }
+.card h4 { margin:.5rem 0 .35rem; font-size:1rem; }
 .card ul { margin:.25rem 0 .5rem 1.2rem; }
+@media print {
+  header.site-head, footer.site-footer, nav { display:none !important; }
+  .card { break-inside: avoid; border:0; padding:0; }
+}
 </style>
-

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,21 @@
+# Tools
+
+Lints and helper scripts live here. They're tiny by design and meant to teach more than impress.
+
+## `lint_sampler.py`
+Checks the hidden critical digital studies sampler page for:
+- required front-matter flags (`noindex`, `sitemap: false`, and `updated`)
+- at least four project cards with alt text and Methods & Ethics bullets
+- no accidental links in `_data/navigation.yml`
+- existence of placeholder images and the PDF sampler
+
+Run it after editing the page or swapping assets:
+
+```bash
+python tools/lint_sampler.py
+```
+
+If it fails, the script will whine loudly and exit non-zero so CI can catch it.
+
+## `lint.py` & `lint_hidden_page.py`
+Legacy lint helpers for other parts of the site. Keep them around if they still serve you; riff on them if not.

--- a/tools/lint_sampler.py
+++ b/tools/lint_sampler.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Bare-bones linter to keep the sampler page ghosted and tidy.
+
+Checks front matter flags, card structure, nav leaks, and placeholder assets.
+If anything's off, we bail loud so the page never ships half-baked.
+"""
+
+import os, re, sys
+
+# Repo root relative to this script; we stay portable when run from anywhere.
+ROOT = os.path.dirname(os.path.abspath(__file__)) + "/.."
+
+# Target page we obsess over.
+page = os.path.join(ROOT, "critical-digital-studies-sampler", "index.md")
+
+# Collect sins here and screech at the end.
+issues = []
+
+# Step 1: make sure the page exists before we start nitpicking.
+if not os.path.exists(page):
+    print("Missing page:", page)
+    sys.exit(1)
+
+txt = open(page, "r", encoding="utf-8").read()
+m = re.search(r"^---(.*?)---", txt, re.S | re.M)
+if not m:
+    issues.append("No YAML front matter.")
+else:
+    fm = m.group(1)
+
+    # Helper to sniff out keys and their values inside the front matter.
+    def has(k, v=None):
+        if v is None:
+            return re.search(rf"^{k}\s*:\s*", fm, re.M)
+        return re.search(rf"^{k}\s*:\s*{re.escape(v)}\s*$", fm, re.M)
+
+    # The page must shout "noindex" and bail from the sitemap.
+    if not has("noindex", "true"):
+        issues.append("Front matter must include: noindex: true")
+    if not has("sitemap", "false"):
+        issues.append("Front matter must include: sitemap: false")
+
+    # Version stamp makes it obvious when the page was last touched.
+    if not has("updated"):
+        issues.append("Front matter missing: updated (YYYY-MM-DD)")
+
+# Check minimum 4 cards and required subparts.
+cards = re.findall(r"<article class=\"card\">(.*?)</article>", txt, re.S)
+if len(cards) < 4:
+    issues.append(f"Expected ≥4 cards, found {len(cards)}.")
+
+# Each card needs an image, alt text, title, ethics list – no exceptions.
+for i, c in enumerate(cards, 1):
+    if "<img " not in c:
+        issues.append(f"Card {i}: missing <img>.")
+    if "alt=" not in c:
+        issues.append(f"Card {i}: image missing alt text.")
+    if "<h3>" not in c:
+        issues.append(f"Card {i}: missing <h3> title.")
+    if "<h4>Methods & Ethics</h4>" not in c:
+        issues.append(f"Card {i}: missing Methods & Ethics section.")
+    if "<ul>" not in c:
+        issues.append(f"Card {i}: missing bullet list.")
+
+# Ensure it's not in nav (if navigation data exists).
+nav = os.path.join(ROOT, "_data", "navigation.yml")
+if os.path.exists(nav):
+    if "critical-digital-studies-sampler" in open(nav, "r", encoding="utf-8").read():
+        issues.append("Hidden page is referenced in _data/navigation.yml; remove the link.")
+
+# Check placeholder assets exist.
+assets = [
+    "assets/images/cds/faceTimes-consent.svg",
+    "assets/images/cds/mn42-panel.svg",
+    "assets/images/cds/glitch-geometry-still.svg",
+    "assets/images/cds/ds200412-still.svg",
+    "assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf"
+]
+for a in assets:
+    if not os.path.exists(os.path.join(ROOT, a)):
+        issues.append(f"Missing asset: {a}")
+
+if issues:
+    print("Sampler checks: FAIL\n- " + "\n- ".join(issues))
+    sys.exit(1)
+
+print("Sampler checks: PASS")


### PR DESCRIPTION
## Summary
- Document sampler assets with teaching-style READMEs and note page is off-nav
- Add portable tools README and verbose comments to `lint_sampler.py`
- Retitle MOARkNOBS card for consistent "open-source microcontroller" phrasing

## Testing
- `jekyll build` (conflict warnings about duplicate about/index files but build completed)
- `python tools/lint_sampler.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7925cc9708325bd0893d552524fb8