### PR TITLE
Fix sampler page styling bleed

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1,8 +1,15 @@
 body {font-family: sans-serif; line-height:1.6; margin:0; padding:0;}
 .site-head nav {display:flex; gap:1rem; padding:1rem;}
 .site-head nav a {text-decoration:none;}
-.cards {display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:1rem;}
-.card {border:1px solid #ccc; padding:0.5rem;}
-.card img {width:100%; height:auto; display:block;}
+.cards { display:grid; gap:1.25rem; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
+.card { border:1px solid #ddd; padding:1rem; border-radius:12px; background:#fff; }
+.card img { max-width:100%; height:auto; border-radius:8px; }
+.card h3 { margin:.6rem 0 .35rem; }
+.card h4 { margin:.5rem 0 .35rem; font-size:1rem; }
+.card ul { margin:.25rem 0 .5rem 1.2rem; }
 a:focus {outline:2px dashed #000; outline-offset:2px;}
 .site-footer {text-align:center; padding:2rem 0; font-size:0.9rem; border-top:1px solid #ddd;}
+@media print {
+  header.site-head, footer.site-footer, nav { display:none !important; }
+  .card { break-inside: avoid; border:0; padding:0; }
+}

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -106,15 +106,3 @@ I pair critical inquiry with hands-on digital practice — *playful rigor*: **bu
 
 <p><a href="/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf">Download PDF sampler</a> (placeholder) • This page is <em>unlisted</em> and marked <code>noindex</code>. Updated: {{ page.updated }}.</p>
 
-<style>
-.cards { display:grid; gap:1.25rem; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
-.card { border:1px solid #ddd; padding:1rem; border-radius:12px; background:#fff; }
-.card img { max-width:100%; height:auto; border-radius:8px; }
-.card h3 { margin:.6rem 0 .35rem; }
-.card h4 { margin:.5rem 0 .35rem; font-size:1rem; }
-.card ul { margin:.25rem 0 .5rem 1.2rem; }
-@media print {
-  header.site-head, footer.site-footer, nav { display:none !important; }
-  .card { break-inside: avoid; border:0; padding:0; }
-}
-</style>


### PR DESCRIPTION
## Summary
- Drop stray inline CSS from the sampler page
- Fold sampler card styles into the main stylesheet

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68c7966c33948325b006d3b1b2131787