### PR TITLE
Refactor CDS sampler into accessible card-driven page

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -1,0 +1,156 @@
+cards:
+  - id: facetimes
+    title: faceTimes — Consent-Forward Vision Station
+    img_src: /assets/images/cds/faceTimes-consent.svg
+    img_alt: faceTimes consent screen showing detection-only, opt-in language and a visible delete-now action
+    abstract: On-device, detection-only pipeline with explicit opt-in and delete-now controls. No identification, no network calls, and no storage without consent. Interface copy foregrounds agency before computation; documentation (README, PRIVACY/ETHICS, assumption ledger) is treated as research output.
+    abstract_locked: true
+    aligns: ["digital literacy","justice/representation","civic engagement"]
+    methods:
+      - Classroom demo & public kiosk contexts
+      - Detection overlay with visible status + erase
+      - System: webcam → local detector → ephemeral buffer → user action
+    outcomes:
+      - Deployed in 1 kiosk (TBD)
+      - Used by ~24 students (TBD)
+      - 3 critique sessions (TBD)
+      - 1 iteration logged (TBD)
+    teach:
+      goal: Practice consent-forward capture as digital literacy
+      lab60: Implement detection-only pipeline; test erase-now; reflect on affordances
+      assess: Process log + assumption ledger + 2-min demo
+    links:
+      - label: Repo
+        url: https://github.com/bseverns/faceTimes
+      - label: Vimeo clip (add link)
+        url: "#"
+        disabled: true
+      - label: PRIVACY/ETHICS (TBD)
+        url: "#"
+        disabled: true
+      - label: Assumption ledger (TBD)
+        url: "#"
+        disabled: true
+
+  - id: moarknobs-42
+    title: MOARkNOBS-42 — open-source microcontroller MIDI controller
+    img_src: /assets/images/cds/mn42-panel.svg
+    img_alt: MOARkNOBS-42 panel top-down with labeled controls
+    abstract: Reproducible hardware + firmware used as both instrument and teaching platform. Parameter mapping functions as an inquiry into authorship and control; latency is characterized and documented so performance claims are auditable and extendable.
+    abstract_locked: true
+    aligns: ["digital literacy","civic engagement"]
+    methods:
+      - Teensy-based instrument + teaching rig
+      - Complete docs: BOM, wiring, parameter map
+      - Measurement folded into practice (latency notes)
+    outcomes:
+      - v0.x performances (TBD)
+      - Latency characterization published (TBD)
+      - Student replicates (TBD)
+    teach:
+      goal: Interface as authorship; documentation as scholarship
+      lab60: Map controls → parameters; measure + log latency
+      assess: Short demo + latency note + reproducibility checklist
+    links:
+      - label: Repo
+        url: https://github.com/bseverns/MOARkNOBS-42
+      - label: Demo video (optional)
+        url: "#"
+        disabled: true
+
+  - id: glitch-geometry
+    title: Glitch Geometry — Audio→Form Instrument
+    img_src: /assets/images/cds/glitch-geometry-still.svg
+    img_alt: Generative geometry frame driven by live audio features
+    abstract: Live translation of signal features into geometry; pipeline choices (feature extraction, modulation, rendering) are made legible as aesthetic and ethical decisions. The system is tunable and documented for both teaching and critique.
+    abstract_locked: true
+    aligns: ["digital literacy","justice/representation"]
+    methods:
+      - Signal in → features → geometry modulation → render
+      - Transparent, documented pipeline for reproducibility
+      - Designed for classroom demos and public performance
+    outcomes:
+      - 1–2 live demos (TBD)
+      - Student mini-studies (TBD)
+    teach:
+      goal: Link form to claim via signal features
+      lab60: Implement 2 features; compare visual behaviors
+      assess: Process log + short critique memo
+    links:
+      - label: Vimeo excerpt (add link)
+        url: "#"
+        disabled: true
+
+  - id: dead-sky
+    title: DEAD SKY — Vision & Motion Grammar Studies
+    img_src: /assets/images/cds/ds200412-still.svg
+    img_alt: Dead Sky rural pursuit still, a lone figure on a November road
+    abstract: Two short studies—rural pursuit (DS200412) and wheel-mounted POV (DS200801)—probing surveillance logics, attention, and embodied capture toward a larger film project. Tests “pursuit grammar” and mechanical vision’s entrainment.
+    abstract_locked: true
+    aligns: ["digital literacy","justice/representation"]
+    methods:
+      - November light, long-lens compression (pursuit grammar)
+      - Wheel POV: cyclic motion & peripheral smear
+      - Consent & site plans for actors/bystanders
+    outcomes:
+      - 2 studies complete; cuts TBD
+      - Screening/critique (TBD)
+    teach:
+      goal: Make camera grammar legible and accountable
+      lab60: Long-lens pursuit vs. wheel-POV; reflect on ethics
+      assess: Shot log + ethics note + 60s cut
+    links:
+      - label: Vimeo profile
+        url: https://vimeo.com/user2746012
+
+  - id: skyway-derive-media-fast
+    title: Skyway Derivé / Media Fast — Critical Pedagogy Interventions
+    img_src: /assets/images/cds/spectacle-mediafast.svg
+    img_alt: Prompt card and public intervention still for Spectacle / Media Fast
+    abstract: Paired interventions that make media power felt: a “Spectacle” action-lecture moves critique into public space; a structured “Media Fast” maps sensory shifts and agency before reflective media making. Designed as public method; prompts and reflections are the artifacts.
+    abstract_locked: true
+    aligns: ["justice/representation","civic engagement"]
+    methods:
+      - Transparent prompts; bystander consent & respect
+      - Reflection before publication; no IDs without release
+      - Documentation pack (brief, roles, reflection prompts)
+    outcomes:
+      - 1 public intervention (TBD)
+      - 1 compiled reflections doc (TBD)
+    teach:
+      goal: Embody critique; document before publish
+      lab60: Skyway dérive with consent checkpoints
+      assess: Reflection + consent notes + debrief
+    links:
+      - label: Brief (TBD)
+        url: "#"
+        disabled: true
+      - label: Reflection template (TBD)
+        url: "#"
+        disabled: true
+
+  - id: mcad-media-2
+    title: MCAD Media 2 — MTN Public Access Broadcast
+    img_src: /assets/images/cds/mcad-media2-mtn.svg
+    img_alt: MCAD Media 2: public access broadcast production still
+    abstract: Studio-seminar culminating in a 28.5-minute MTN broadcast planned, produced, and edited by students. The artifact is civic-facing media formed by calendars, critique gates, and documentation standards for longevity.
+    abstract_locked: true
+    aligns: ["civic engagement","digital literacy"]
+    methods:
+      - Roles & calendars; consent and authorship checkpoints
+      - Deliverables: broadcast master + process docs
+      - Public exhibition as peer review
+    outcomes:
+      - 28.5-minute episode delivered (TBD)
+      - Airtime / reach (TBD)
+    teach:
+      goal: Practice public-facing media with accountability
+      lab60: Segment planning → critique gate → deliver
+      assess: Checklists + credits + release archive
+    links:
+      - label: Episode link (TBD)
+        url: "#"
+        disabled: true
+      - label: Production calendar (TBD)
+        url: "#"
+        disabled: true

--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -1,0 +1,46 @@
+<article id="{{ include.id }}" class="card" role="region" aria-labelledby="{{ include.id }}-title">
+  <div class="ribbon">
+    {% for tag in include.aligns %}
+    <span class="tag">{{ tag }}</span>
+    {% endfor %}
+  </div>
+  {% if include.img_src %}
+  <figure>
+    <img src="{{ include.img_src }}" alt="{{ include.img_alt }}">
+    {% if include.figcaption %}<figcaption>{{ include.figcaption }}</figcaption>{% endif %}
+  </figure>
+  {% endif %}
+  <h3 id="{{ include.id }}-title">{{ include.title }}</h3>
+  <p>{{ include.abstract }}</p>
+  <h4>Methods &amp; Ethics</h4>
+  <ul>
+    {% for m in include.methods %}
+    <li>{{ m }}</li>
+    {% endfor %}
+  </ul>
+  {% if include.outcomes %}
+  <h4>Outcomes</h4>
+  <ul>
+    {% for o in include.outcomes %}
+    <li>{{ o }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  <h4>Teach with this</h4>
+  <ul>
+    <li><strong>Goal:</strong> {{ include.teach.goal }}</li>
+    <li><strong>60-min lab:</strong> {{ include.teach.lab60 }}</li>
+    <li><strong>Assess:</strong> {{ include.teach.assess }}</li>
+  </ul>
+  {% if include.links %}
+  <p class="links">
+    {% for l in include.links %}
+      {% if l.disabled %}
+      <a href="{{ l.url }}" aria-disabled="true">{{ l.label }}</a>{% if forloop.last == false %} • {% endif %}
+      {% else %}
+      <a href="{{ l.url }}" rel="nofollow noopener">{{ l.label }}</a>{% if forloop.last == false %} • {% endif %}
+      {% endif %}
+    {% endfor %}
+  </p>
+  {% endif %}
+</article>

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -1,0 +1,63 @@
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  background: #000;
+  color: #fff;
+  padding: 0.5rem;
+  z-index: 1000;
+}
+
+a:focus,
+button:focus {
+  outline: 2px solid #000;
+  outline-offset: 2px;
+}
+
+.card {
+  position: relative;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+.ribbon {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+}
+
+.tag {
+  display: inline-block;
+  background: #eee;
+  border-radius: 0.25rem;
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+}
+
+@media print {
+  nav,
+  .toc,
+  .print-btn,
+  .skip-link {
+    display: none !important;
+  }
+  a[href]:after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+  }
+  .card {
+    page-break-inside: avoid;
+  }
+  img {
+    max-width: 100%;
+  }
+  body {
+    font-size: 11pt;
+  }
+}

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -7,102 +7,33 @@ sitemap: false
 noindex: true
 updated: "2025-09-14"
 ---
-
-<!-- Ghost page — keep it off the nav and out of search. Swappable assets live in /assets/images/cds/ and /assets/docs/. -->
+<link rel="stylesheet" href="{{ '/assets/css/print-cds.css' | relative_url }}">
+<a class="skip-link" href="#sampler-content">Skip to content</a>
 
 # Critical Digital Studies — Sampler (Unlisted)
 
-I pair critical inquiry with hands-on digital practice — *playful rigor*: **build → perform → document → iterate**. Working **systems-first**, I map technical / operational / ethical layers and translate them into scaffolds, demos, and documentation others can use, audit, and extend. This unlisted page gathers practice-based work across consent-forward vision, open hardware, audio→form pipelines, and film/vision grammar.
+<button class="print-btn" type="button" onclick="window.print()">Download PDF</button>
 
-<div class="cards">
+<aside class="service">
+  <h2>Service &amp; Stewardship</h2>
+  <p>Lab stewardship and equitable access are part of the pedagogy: labeled, calibrated, reproducible. I served 2.5 years on MCAD’s Faculty Senate, collaborating across faculty and administration on curriculum and student support; I bring the same steady, equity-minded approach to committee work.</p>
+</aside>
 
-<!-- CARD 1 -->
-<article class="card">
-  <img src="/assets/images/cds/faceTimes-consent.svg" alt="faceTimes consent screen showing detection-only, opt-in language and a visible delete-now action">
-  <h3>faceTimes — Consent-Forward Vision Station</h3>
-  <p>On-device, <strong>detection-only</strong> pipeline with explicit opt-in and delete-now controls. No identification, no network calls, and no storage without consent. Interface copy foregrounds agency before computation; documentation (README, PRIVACY/ETHICS, assumption ledger) is treated as research output.</p>
-  <h4>Methods & Ethics</h4>
+<p>I pair critical inquiry with hands-on digital practice—playful rigor: build → perform → document → iterate. Working systems-first, I make technical and ethical layers legible so students can audit and extend them. This sampler foregrounds digital literacy within questions of justice, representation, and civic engagement, preparing makers to treat media as civic instruments.</p>
+
+<nav class="toc" aria-label="Projects">
   <ul>
-    <li>Classroom demo & public kiosk contexts</li>
-    <li>Detection overlay with visible status + erase</li>
-    <li>System: webcam → local detector → ephemeral buffer → user action</li>
+  {% for c in site.data.cds.cards %}
+    <li><a href="#{{ c.id }}">{{ c.title }}</a></li>
+  {% endfor %}
   </ul>
-  <p><a href="https://github.com/bseverns/faceTimes">Repo</a> • <a href="#" aria-disabled="true">Vimeo clip (add link)</a></p>
-</article>
+</nav>
 
-<!-- CARD 2 -->
-<article class="card">
-  <img src="/assets/images/cds/mn42-panel.svg" alt="MOARkNOBS-42 panel top-down with labeled controls">
-  <h3>MOARkNOBS-42 — open-source microcontroller MIDI controller</h3>
-  <p>Reproducible hardware + firmware used as both instrument and teaching platform. Parameter mapping functions as an inquiry into authorship and control; latency is characterized and documented so performance claims are auditable and extendable.</p>
-  <h4>Methods & Ethics</h4>
-  <ul>
-    <li>Teensy-based instrument + teaching rig</li>
-    <li>Complete docs: BOM, wiring, parameter map</li>
-    <li>Measurement folded into practice (latency notes)</li>
-  </ul>
-  <p><a href="https://github.com/bseverns/MOARkNOBS-42">Repo</a> • <a href="#" aria-disabled="true">Demo video (optional)</a></p>
-</article>
-
-<!-- CARD 3 -->
-<article class="card">
-  <img src="/assets/images/cds/glitch-geometry-still.svg" alt="Generative geometry frame driven by live audio features">
-  <h3>Glitch Geometry — Audio→Form Instrument</h3>
-  <p>Live translation of signal features into geometry; pipeline choices (feature extraction, modulation, rendering) are made legible as aesthetic and ethical decisions. The system is tunable and documented for both teaching and critique.</p>
-  <h4>Methods & Ethics</h4>
-  <ul>
-    <li>Signal in → features → geometry modulation → render</li>
-    <li>Transparent, documented pipeline for reproducibility</li>
-    <li>Designed for classroom demos and public performance</li>
-  </ul>
-  <p><a href="#" aria-disabled="true">Vimeo excerpt (add link)</a></p>
-</article>
-
-<!-- CARD 4 -->
-<article class="card">
-  <img src="/assets/images/cds/ds200412-still.svg" alt="Dead Sky rural pursuit still, a lone figure on a November road">
-  <h3>DEAD SKY — Vision & Motion Grammar Studies</h3>
-  <p>Two short studies — rural pursuit (DS200412) and wheel-mounted POV (DS200801) — probing surveillance logics, attention, and embodied capture toward a larger film project. Tests “pursuit grammar” and mechanical vision’s entrainment.</p>
-  <h4>Methods & Ethics</h4>
-  <ul>
-    <li>November light, long-lens compression (pursuit grammar)</li>
-    <li>Wheel POV: cyclic motion & peripheral smear</li>
-    <li>Consent & site plans for actors / bystanders</li>
-  </ul>
-  <p><a href="https://vimeo.com/user2746012">Vimeo profile</a> (clip timecodes TBD)</p>
-</article>
-
-<!--CARD 5-->
-<article class="card">
-  <img src="/assets/images/cds/spectacle-mediafast.svg" alt="Prompt card and public intervention still for Spectacle / Media Fast">
-  <h3>Skyway Derivé / Media Fast — Critical Pedagogy Interventions</h3>
-  <p>Paired interventions that make media power felt: a “Spectacle” action-lecture moves critique into public space; a structured “Media Fast” maps sensory shifts and agency before reflective media making. Designed as public method; prompts and reflections are the artifacts.</p>
-  <h4>Methods & Ethics</h4>
-  <ul>
-    <li>Transparent prompts; bystander consent & respect</li>
-    <li>Reflection before publication; no IDs without release</li>
-    <li>Documentation pack (brief, roles, reflection prompts)</li>
-  </ul>
-  <p><a href="#" aria-disabled="true">Brief</a> • <a href="#" aria-disabled="true">Reflection template</a></p>
-</article>
-
-<!--CARD 6 - cut best sample from final Media 2 episodes-->
-<article class="card">
-  <img src="/assets/images/cds/mcad-media2-mtn.svg" alt="MCAD Media 2: public access broadcast production still">
-  <h3>MCAD Media 2 — MTN Public Access Broadcast</h3>
-  <p>Studio-seminar culminating in a 28.5-minute MTN broadcast planned, produced, and edited by students. The artifact is civic-facing media formed by calendars, critique gates, and documentation standards for longevity.</p>
-  <h4>Methods & Ethics</h4>
-  <ul>
-    <li>Roles & calendars; consent and authorship checkpoints</li>
-    <li>Deliverables: broadcast master + process docs</li>
-    <li>Public exhibition as peer review</li>
-  </ul>
-  <p><a href="#" aria-disabled="true">Episode link</a> • <a href="#" aria-disabled="true">Production calendar</a></p>
-</article>
-
+<div id="sampler-content">
+{% for c in site.data.cds.cards %}
+{% include cds-card.html id=c.id title=c.title img_src=c.img_src img_alt=c.img_alt figcaption=c.figcaption abstract=c.abstract aligns=c.aligns methods=c.methods outcomes=c.outcomes teach=c.teach links=c.links %}
+{% endfor %}
 </div>
 
 <hr>
-
-<p><a href="/assets/docs/Severns_CriticalDigitalStudies_Sampler.pdf">Download PDF sampler</a> (placeholder) • This page is <em>unlisted</em> and marked <code>noindex</code>. Updated: {{ page.updated }}.</p>
-
+<p>This page is <em>unlisted</em> and marked <code>noindex</code>. Updated: {{ page.updated }}.</p>


### PR DESCRIPTION
## Summary
- add reusable `cds-card` include and data model to drive sampler page
- introduce print-friendly CSS and skip link/focus helpers
- rebuild sampler page with TOC, service sidebar, and uniform cards

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c79ec36d10832589cd2be7738231c6