### PR TITLE
Fix YAML formatting for Skyway Derivé abstract

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -107,7 +107,11 @@ cards:
     title: Skyway Derivé / Media Fast — Critical Pedagogy Interventions
     img_src: /assets/images/cds/spectacle-mediafast.svg
     img_alt: Prompt card and public intervention still for Spectacle / Media Fast
-    abstract: Paired interventions that make media power felt: a “Spectacle” action-lecture moves critique into public space; a structured “Media Fast” maps sensory shifts and agency before reflective media making. Designed as public method; prompts and reflections are the artifacts.
+    abstract: >-
+      Paired interventions that make media power felt: a “Spectacle” action-lecture moves
+      critique into public space; a structured “Media Fast” maps sensory shifts and agency
+      before reflective media making. Designed as public method; prompts and reflections are
+      the artifacts.
     abstract_locked: true
     aligns: ["justice/representation","civic engagement"]
     methods:


### PR DESCRIPTION
## Summary
- replace the long Skyway Derivé abstract with a folded block string so the YAML parser accepts its embedded colon

## Testing
- python tools/lint_sampler.py *(fails: Expected ≥4 cards, found 0 — pre-existing regex limitation with Liquid includes)*

------
https://chatgpt.com/codex/tasks/task_e_68c879f0866c832596858c36d34afb4d