### PR TITLE
Refine CDS sampler cards and metadata

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -22,6 +22,12 @@ cards:
     links:
       - label: Repo
         url: https://github.com/bseverns/faceTimes
+      - label: ETHICS
+        url: https://github.com/bseverns/faceTimes/blob/main/ETHICS.md
+      - label: PRIVACY
+        url: https://github.com/bseverns/faceTimes/blob/main/PRIVACY.md
+      - label: Data-flow diagram
+        url: https://github.com/bseverns/faceTimes/blob/main/diagrams.md
       - label: Vimeo clip (add link)
         url: "#"
         disabled: true
@@ -57,6 +63,14 @@ cards:
       - label: Demo video (optional)
         url: "#"
         disabled: true
+      - label: Release (latest)
+        url: https://github.com/bseverns/MOARkNOBS-42/releases/latest
+      - label: Testing gauntlet
+        url: https://github.com/bseverns/MOARkNOBS-42/blob/main/docs/TESTING.md
+      - label: Pin map
+        url: https://github.com/bseverns/MOARkNOBS-42/blob/main/docs/PinMap.md
+      - label: Hardware docs
+        url: https://github.com/bseverns/MOARkNOBS-42/tree/main/hardware
 
   - id: glitch-geometry
     title: Glitch Geometry — Audio→Form Instrument
@@ -77,6 +91,10 @@ cards:
       lab60: Implement 2 features; compare visual behaviors
       assess: Process log + short critique memo
     links:
+      - label: Repo (GlitchListener)
+        url: https://github.com/bseverns/GlitchListener
+      - label: README quickstart
+        url: https://github.com/bseverns/GlitchListener#readme
       - label: Vimeo excerpt (add link)
         url: "#"
         disabled: true
@@ -102,6 +120,8 @@ cards:
     links:
       - label: Vimeo profile
         url: https://vimeo.com/user2746012
+      - label: Related tool: VidObjectifier
+        url: https://github.com/bseverns/VidObjectifier
 
   - id: skyway-derive-media-fast
     title: Skyway Derivé / Media Fast — Critical Pedagogy Interventions
@@ -129,9 +149,13 @@ cards:
       - label: Brief (TBD)
         url: "#"
         disabled: true
+      - label: Briefs (Syllabus)
+        url: https://github.com/bseverns/Syllabus/tree/main/future-course-briefs
       - label: Reflection template (TBD)
         url: "#"
         disabled: true
+      - label: Policies / templates (Syllabus/shared)
+        url: https://github.com/bseverns/Syllabus/tree/main/shared
 
   - id: mcad-media-2
     title: MCAD Media 2 — MTN Public Access Broadcast
@@ -158,3 +182,7 @@ cards:
       - label: Production calendar (TBD)
         url: "#"
         disabled: true
+      - label: Course materials
+        url: https://github.com/bseverns/Syllabus/tree/main/MCADMedia2
+      - label: p5 code explainers
+        url: https://github.com/bseverns/Syllabus/tree/main/MCADMedia2/MEDIA2-codeEXPLAINERS

--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -7,38 +7,49 @@
 
   {% if include.img_src %}
   <figure>
-    <img src="{{ include.img_src }}" alt="{{ include.img_alt | default: include.title | escape }}">
+    <img
+      src="{{ include.img_src }}"
+      alt="{{ include.img_alt | default: include.title | escape }}"
+      loading="lazy" decoding="async"
+      {% if include.img_w %}width="{{ include.img_w }}"{% else %}width="1200"{% endif %}
+      {% if include.img_h %}height="{{ include.img_h }}"{% else %}height="675"{% endif %}>
     {% if include.figcaption %}<figcaption>{{ include.figcaption }}</figcaption>{% endif %}
   </figure>
   {% endif %}
 
-  <h3 id="{{ include.id }}-title">{{ include.title }}</h3>
-  <p>{{ include.abstract }}</p>
+  <h2 id="{{ include.id }}-title">{{ include.title }}</h2>
+  {% if include.abstract %}<p>{{ include.abstract }}</p>{% endif %}
 
   {% if include.methods and include.methods.size > 0 %}
-  <h4>Methods &amp; Ethics</h4>
+  <h3>Methods &amp; Ethics</h3>
   <ul>{% for m in include.methods %}<li>{{ m }}</li>{% endfor %}</ul>
   {% endif %}
 
   {% if include.outcomes and include.outcomes.size > 0 %}
-  <h4>Outcomes</h4>
+  <h3>Outcomes</h3>
   <ul>{% for o in include.outcomes %}<li>{{ o }}</li>{% endfor %}</ul>
   {% endif %}
 
   {% if include.teach %}
-  <h4>Teach with this</h4>
+  {% assign t = include.teach %}
+  {% if t.goal or t.lab60 or t.assess %}
+  <h3>Teach with this</h3>
   <ul>
-    {% if include.teach.goal %}<li><strong>Goal:</strong> {{ include.teach.goal }}</li>{% endif %}
-    {% if include.teach.lab60 %}<li><strong>60-min lab:</strong> {{ include.teach.lab60 }}</li>{% endif %}
-    {% if include.teach.assess %}<li><strong>Assess:</strong> {{ include.teach.assess }}</li>{% endif %}
+    {% if t.goal %}<li><strong>Goal:</strong> {{ t.goal }}</li>{% endif %}
+    {% if t.lab60 %}<li><strong>60-min lab:</strong> {{ t.lab60 }}</li>{% endif %}
+    {% if t.assess %}<li><strong>Assess:</strong> {{ t.assess }}</li>{% endif %}
   </ul>
+  {% endif %}
   {% endif %}
 
   {% if include.links and include.links.size > 0 %}
   <p class="links">
     {% for l in include.links %}
+      {% assign is_ext = l.url | downcase | slice: 0, 4 %}
       <a href="{{ l.url | default:'#' }}"
-         {% if l.disabled %}aria-disabled="true"{% else %}rel="nofollow noopener"{% endif %}>{{ l.label }}</a>{% unless forloop.last %} • {% endunless %}
+         {% if l.disabled %}aria-disabled="true"{% elsif is_ext == 'http' %}rel="nofollow noopener"{% endif %}>
+        {{ l.label }}
+      </a>{% unless forloop.last %} • {% endunless %}
     {% endfor %}
   </p>
   {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,9 @@
-<!doctype html><html lang="en"><head>{% include head.html %}</head>
+<!doctype html>
+<html lang="en">
+<head>
+  {% include head.html %}
+  {% if page.noindex %}<meta name="robots" content="noindex,nofollow">{% endif %}
+</head>
 <body>
 <header class="site-head">
   <nav>
@@ -9,4 +14,5 @@
 </header>
 <main id="content">{{ content }}</main>
 {% include footer.html %}
-</body></html>
+</body>
+</html>

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -1,63 +1,21 @@
-.skip-link {
-  position: absolute;
-  left: -9999px;
-}
-.skip-link:focus {
-  left: 0;
-  top: 0;
-  background: #000;
-  color: #fff;
-  padding: 0.5rem;
-  z-index: 1000;
-}
+/* Focus & skip */
+.skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;}
+.skip-link:focus{left:1rem;top:1rem;width:auto;height:auto;padding:.5rem 1rem;background:#fff;border:2px solid #000;z-index:1000;}
+:focus{outline:3px solid;outline-offset:2px}
 
-a:focus,
-button:focus {
-  outline: 2px solid #000;
-  outline-offset: 2px;
-}
+/* Cards & ribbons */
+.card{border:1px solid #e2e2e2;border-radius:14px;padding:1rem;margin:1rem 0}
+.card .tag{display:inline-block;border:1px solid #999;border-radius:999px;padding:.1rem .5rem;margin-right:.25rem;font-size:.8rem}
+.links a[aria-disabled="true"]{pointer-events:none;opacity:.55;text-decoration:none}
+.ribbon{position:absolute;top:.75rem;right:.75rem;display:flex;flex-wrap:wrap;gap:.25rem;justify-content:flex-end}
 
-.card {
-  position: relative;
-  border: 1px solid #ccc;
-  border-radius: 0.5rem;
-  padding: 1rem;
-  margin: 1rem 0;
-}
-
-.ribbon {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-}
-
-.tag {
-  display: inline-block;
-  background: #eee;
-  border-radius: 0.25rem;
-  padding: 0 0.25rem;
-  font-size: 0.75rem;
-  margin-left: 0.25rem;
-}
-
-@media print {
-  nav,
-  .toc,
-  .print-btn,
-  .skip-link {
-    display: none !important;
-  }
-  a[href]:after {
-    content: " (" attr(href) ")";
-    font-size: 0.8em;
-  }
-  .card {
-    page-break-inside: avoid;
-  }
-  img {
-    max-width: 100%;
-  }
-  body {
-    font-size: 11pt;
-  }
+/* Print polish */
+@page{margin:0.6in}
+@media print{
+  nav,.print-btn,.skip-link{display:none!important}
+  a[href]:after{content:" (" attr(href) ")";font-size:80%}
+  .card{break-inside:avoid}
+  h1,h2,h3{page-break-after:avoid}
+  img{max-width:100%;height:auto}
+  body{font-size:11pt;line-height:1.35}
 }

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -37,3 +37,9 @@ updated: "2025-09-14"
 
 <hr>
 <p>This page is <em>unlisted</em> and marked <code>noindex</code>. Updated: {{ page.updated }}.</p>
+
+<small>
+  Sampler commit:
+  {% if site.github and site.github.build_revision %}{{ site.github.build_revision | slice:0,7 }}{% else %}local{% endif %}
+  • Updated {{ page.updated }}
+</small>


### PR DESCRIPTION
## Summary
- refresh the sampler card include for improved heading hierarchy, lazy-loading images, and conditional external link handling
- update the CDS print stylesheet for focus visibility, inert disabled links, and cleaner print layout
- add conditional noindex robots meta, provenance footer, and expand sampler data links for the new resources

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a06128cc8325b09e706f4fca9531