### PR TITLE
Keep arrow phrases intact in sampler

### DIFF
--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -18,16 +18,44 @@
   {% endif %}
 
   <h2 id="{{ include.id }}-title">{{ include.title }}</h2>
-  {% if include.abstract %}<p>{{ include.abstract }}</p>{% endif %}
+  {% if include.abstract %}
+  <p>
+    {% if include.abstract contains ' → ' %}
+      {% include flow-chain.html text=include.abstract class="flow-chain--paragraph" %}
+    {% else %}
+      {{ include.abstract }}
+    {% endif %}
+  </p>
+  {% endif %}
 
   {% if include.methods and include.methods.size > 0 %}
   <h3>Methods &amp; Ethics</h3>
-  <ul>{% for m in include.methods %}<li>{{ m }}</li>{% endfor %}</ul>
+  <ul>
+  {% for m in include.methods %}
+    <li>
+      {% if m contains ' → ' %}
+        {% include flow-chain.html text=m class="flow-chain--list" %}
+      {% else %}
+        {{ m }}
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
   {% endif %}
 
   {% if include.outcomes and include.outcomes.size > 0 %}
   <h3>Outcomes</h3>
-  <ul>{% for o in include.outcomes %}<li>{{ o }}</li>{% endfor %}</ul>
+  <ul>
+  {% for o in include.outcomes %}
+    <li>
+      {% if o contains ' → ' %}
+        {% include flow-chain.html text=o class="flow-chain--list" %}
+      {% else %}
+        {{ o }}
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
   {% endif %}
 
   {% if include.teach %}
@@ -35,9 +63,36 @@
   {% if t.goal or t.lab60 or t.assess %}
   <h3>Teach with this</h3>
   <ul>
-    {% if t.goal %}<li><strong>Goal:</strong> {{ t.goal }}</li>{% endif %}
-    {% if t.lab60 %}<li><strong>60-min lab:</strong> {{ t.lab60 }}</li>{% endif %}
-    {% if t.assess %}<li><strong>Assess:</strong> {{ t.assess }}</li>{% endif %}
+    {% if t.goal %}
+    <li>
+      <strong>Goal:</strong>
+      {% if t.goal contains ' → ' %}
+        {% include flow-chain.html text=t.goal class="flow-chain--inline" %}
+      {% else %}
+        {{ t.goal }}
+      {% endif %}
+    </li>
+    {% endif %}
+    {% if t.lab60 %}
+    <li>
+      <strong>60-min lab:</strong>
+      {% if t.lab60 contains ' → ' %}
+        {% include flow-chain.html text=t.lab60 class="flow-chain--inline" %}
+      {% else %}
+        {{ t.lab60 }}
+      {% endif %}
+    </li>
+    {% endif %}
+    {% if t.assess %}
+    <li>
+      <strong>Assess:</strong>
+      {% if t.assess contains ' → ' %}
+        {% include flow-chain.html text=t.assess class="flow-chain--inline" %}
+      {% else %}
+        {{ t.assess }}
+      {% endif %}
+    </li>
+    {% endif %}
   </ul>
   {% endif %}
   {% endif %}

--- a/_includes/flow-chain.html
+++ b/_includes/flow-chain.html
@@ -1,0 +1,21 @@
+{% assign root_tag = include.tag | default: 'span' %}
+{% assign extra_class = '' %}
+{% if include.class %}
+  {% assign extra_class = ' ' | append: include.class %}
+{% endif %}
+<{{ root_tag }} class="flow-chain{{ extra_class }}">
+  {% assign segments = include.text | split: '→' %}
+  {% for segment in segments %}
+    {% assign trimmed = segment | strip %}
+    {% if trimmed != '' %}
+    <span class="flow-node">
+      {% if forloop.first %}
+      <span class="flow-label">{{ trimmed | escape_once }}</span>
+      {% else %}
+      <span class="flow-arrow">→</span>
+      <span class="flow-label">{{ trimmed | escape_once }}</span>
+      {% endif %}
+    </span>
+    {% endif %}
+  {% endfor %}
+</{{ root_tag }}>

--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -102,6 +102,67 @@ main#content {
   color: #334155;
 }
 
+.flow-chain {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.65rem;
+  vertical-align: baseline;
+}
+
+.flow-chain .flow-node {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.flow-chain .flow-arrow {
+  font-weight: 650;
+  color: #1d4ed8;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.9em;
+}
+
+.flow-chain .flow-label {
+  display: inline;
+  white-space: normal;
+}
+
+.flow-chain--lede {
+  font-weight: 650;
+  gap: 0.4rem 0.8rem;
+  letter-spacing: 0.01em;
+}
+
+.flow-chain--lede .flow-arrow {
+  font-size: 1em;
+  color: #1e3a8a;
+}
+
+.flow-chain--paragraph {
+  gap: 0.35rem 0.7rem;
+  line-height: 1.6;
+}
+
+.flow-chain--list {
+  gap: 0.25rem 0.55rem;
+}
+
+.flow-chain--list .flow-arrow {
+  font-size: 0.85em;
+  color: #2563eb;
+}
+
+.flow-chain--inline {
+  gap: 0.3rem 0.5rem;
+}
+
+.flow-chain--inline .flow-arrow {
+  font-size: 0.85em;
+}
+
 .print-btn {
   border: 0;
   border-radius: 999px;

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -146,4 +146,12 @@
     max-width: 100%;
     height: auto;
   }
+
+  .flow-chain {
+    gap: 0.2rem 0.45rem;
+  }
+
+  .flow-chain .flow-arrow {
+    color: #111827;
+  }
 }

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -18,7 +18,7 @@ updated: "2025-09-14"
         <h1 id="sampler-title">Critical Digital Studies — Sampler (Unlisted)</h1>
         <button class="print-btn" type="button" onclick="window.print()">Download PDF</button>
       </div>
-      <p class="lede">I pair critical inquiry with hands-on digital practice—playful rigor: build → perform (play) → document → iterate.</p>
+      <p class="lede">I pair critical inquiry with hands-on digital practice—playful rigor: {% include flow-chain.html text="build → perform (play) → document → iterate" class="flow-chain--lede" %}.</p>
       <p>Working systems-first, I make technical and ethical layers legible so students can audit and extend them. This sampler foregrounds digital literacy within questions of justice, representation, and civic engagement, preparing makers to treat media as civic instruments.</p>
     </div>
     <aside class="service">


### PR DESCRIPTION
## Summary
- add a reusable `flow-chain` include to format “→” phrases as flexible, non-breaking segments
- update the sampler hero text and card template so arrow-driven sequences render through the new helper
- style the flow chain for screen and print so PDF exports keep phrases intact without awkward wraps

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8b9f6610483258e6dbde93bc3044f