### PR TITLE
Link Skyway dérive resources to syllabus docs

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -162,14 +162,12 @@ cards:
       lab60: Skyway dérive with consent checkpoints
       assess: Reflection + consent notes + debrief
     links:
-      - label: Brief (TBD)
-        url: "#"
-        disabled: true
-      - label: Briefs (Syllabus)
-        url: https://github.com/bseverns/Syllabus/tree/main/future-course-briefs
-      - label: Reflection template (TBD)
-        url: "#"
-        disabled: true
+      - label: Skyway dérive walking score (Media 1/2)
+        url: https://github.com/bseverns/Syllabus/blob/main/MCADMedia2/Walking%20in%20the%20Skyway.docx
+      - label: Media Fast assignment brief (Media 2)
+        url: https://github.com/bseverns/Syllabus/blob/main/MCADMedia2/Media%202%20SP21%20PROJECT%202_%20Media%20Fast.docx
+      - label: Media Fast reflection pack (Media 2 folder)
+        url: https://github.com/bseverns/Syllabus/blob/main/MCADMedia2/Media%20Fast%20Exercise%20FOLDER/Assignment%20Instructions%20-%20MEDIA%20FAST.docx
       - label: Policies / templates (Syllabus/shared)
         url: https://github.com/bseverns/Syllabus/tree/main/shared
 


### PR DESCRIPTION
## Summary
- wire up the Skyway dérive / Media Fast resource links to the actual Media 1/2 assignment sheets living in the Syllabus repo

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9ae0c9540832589250fc54f9bea10