### PR TITLE
Restyle CDS sampler ribbons as note badges

### DIFF
--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -333,11 +333,12 @@ nav.toc a:focus-visible {
 }
 
 .cds-card {
+  --card-pad: clamp(1.65rem, 3vw, 2.25rem);
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  padding: clamp(1.65rem, 3vw, 2.25rem);
+  padding: var(--card-pad);
   border-radius: 26px;
   border: 1px solid rgba(203, 213, 225, 0.85);
   background: rgba(255, 255, 255, 0.94);
@@ -359,7 +360,7 @@ nav.toc a:focus-visible {
 }
 
 .cds-card figure {
-  margin: -1.65rem -1.65rem 0;
+  margin: 0 calc(var(--card-pad) * -1) 0;
   border-radius: 18px;
   overflow: hidden;
   background: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(226, 232, 240, 0.2));
@@ -378,35 +379,80 @@ nav.toc a:focus-visible {
 }
 
 .cds-card .ribbon {
-  position: absolute;
-  top: 1.25rem;
-  right: 1.35rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  justify-content: flex-end;
+  position: relative;
+  display: grid;
+  justify-items: end;
+  gap: 0.45rem;
+  align-self: flex-end;
+  margin: -0.35rem -0.15rem 0 0;
+  padding-top: 0.35rem;
+  max-width: min(62%, 11.5rem);
+  text-align: right;
 }
 
 .cds-card .tag {
-  background: rgba(37, 99, 235, 0.88);
-  color: #f8fafc;
-  font-size: 0.68rem;
-  letter-spacing: 0.14em;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.9rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 18px 18px 16px 16px;
+  background: linear-gradient(145deg, #fff9d6 0%, #fff0bd 55%, #fffbea 100%);
+  border: 1px solid rgba(217, 119, 6, 0.3);
+  box-shadow: 0 18px 28px -24px rgba(15, 23, 42, 0.65), 0 6px 16px -14px rgba(124, 58, 18, 0.45);
+  color: #7c2d12;
+  font-size: 0.7rem;
+  letter-spacing: 0.13em;
   text-transform: uppercase;
+  line-height: 1.1;
+  transform-origin: center;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.cds-card .tag::before {
+  content: "";
+  position: absolute;
+  top: -0.55rem;
+  left: 24%;
+  width: 52%;
+  height: 0.4rem;
   border-radius: 999px;
-  padding: 0.2rem 0.75rem;
+  background: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 4px 10px -8px rgba(124, 58, 18, 0.6);
+}
+
+.cds-card .tag:nth-child(odd) {
+  transform: rotate(-1.75deg);
+}
+
+.cds-card .tag:nth-child(even) {
+  transform: rotate(1.35deg);
+}
+
+.cds-card .tag:focus-visible,
+.cds-card .tag:hover {
+  transform: rotate(0deg) translateY(-1px);
+  box-shadow: 0 16px 36px -24px rgba(15, 23, 42, 0.7), 0 8px 18px -14px rgba(124, 58, 18, 0.5);
 }
 
 @media (max-width: 640px) {
   .cds-card figure {
-    margin: -1.35rem -1.35rem 0;
+    margin: 0 calc(var(--card-pad) * -1) 0;
     border-radius: 16px;
   }
 
   .cds-card .ribbon {
-    position: static;
-    justify-content: flex-start;
-    margin-bottom: 0.35rem;
+    justify-items: start;
+    margin: 0 0 0.5rem;
+    max-width: none;
+    text-align: left;
+  }
+
+  .cds-card .tag,
+  .cds-card .tag:nth-child(odd),
+  .cds-card .tag:nth-child(even) {
+    transform: rotate(0deg);
   }
 }
 

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -125,6 +125,12 @@
     border: 1px solid #475569;
     color: #111827;
     background: none;
+    box-shadow: none;
+    transform: none;
+  }
+
+  .cds-card .tag::before {
+    display: none;
   }
 
   .cds-card .links {


### PR DESCRIPTION
## Summary
- restyled the CDS sampler ribbon layout so the alignment tags render as layered note badges that no longer occlude imagery and are spaced with a shared card padding variable
- tweaked the mobile and hover treatments to keep the note badges legible while flattening the effect for print output

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b8a6e7108325ae5b73ee1c96dc84