### PR TITLE
Improve responsive layout for CDS sampler page

### DIFF
--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -26,7 +26,7 @@ main#content {
 }
 
 .cds-sampler {
-  max-width: 1100px;
+  max-width: min(1320px, 96vw);
   margin: clamp(1.5rem, 4vw, 3rem) auto clamp(3rem, 8vw, 5rem);
   padding: clamp(2.5rem, 4vw, 3.75rem);
   background: rgba(255, 255, 255, 0.94);
@@ -324,11 +324,18 @@ nav.toc a:focus-visible {
   display: grid;
   gap: clamp(1.75rem, 3.5vw, 2.6rem);
   scroll-margin-top: 5rem;
+  grid-template-columns: minmax(0, 1fr);
 }
 
-@media (min-width: 620px) {
+@media (min-width: 820px) {
   #sampler-content {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  #sampler-content {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- widen the CDS sampler container so cards keep their impact on large displays
- replace the auto-fit grid with explicit one-, two-, and three-column breakpoints for different screen sizes

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9bbb63c8083258ccf510068108303