### PR TITLE
Tighten print layout for CDS sampler PDF

### DIFF
--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -44,23 +44,23 @@
   }
 
   body {
-    font-size: 10.5pt;
-    line-height: 1.32;
+    font-size: 10.25pt;
+    line-height: 1.28;
     background: #fff;
     color: #0f172a;
   }
 
   p {
-    margin: 0 0 0.45rem;
+    margin: 0 0 0.35rem;
   }
 
   ul {
-    margin: 0 0 0.55rem;
-    padding-left: 1rem;
+    margin: 0 0 0.45rem;
+    padding-left: 0.95rem;
   }
 
   li {
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.15rem;
   }
 
   li:last-child {
@@ -69,7 +69,8 @@
 
   a[href]:after {
     content: " (" attr(href) ")";
-    font-size: 80%;
+    font-size: 70%;
+    word-break: break-all;
   }
 
   .cds-sampler {
@@ -132,7 +133,7 @@
     box-shadow: none;
     border: 1px solid #cbd5e1;
     background: #fff;
-    padding: 1.25rem 1.35rem;
+    padding: 1rem 1.2rem;
     margin: 0;
   }
 
@@ -141,13 +142,13 @@
   }
 
   .cds-card figure {
-    margin: 0 0 0.65rem;
+    margin: 0 0 0.5rem;
     border-radius: 0;
   }
 
   .cds-card figure img {
     width: 100%;
-    max-height: 3.6in;
+    max-height: 3.3in;
     object-fit: cover;
   }
 
@@ -191,12 +192,12 @@
   .cds-card h3 {
     font-size: 1.05rem;
     letter-spacing: 0.01em;
-    margin-top: 0.6rem;
-    margin-bottom: 0.35rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.3rem;
   }
 
   .cds-card h3 + ul {
-    margin-top: 0.1rem;
+    margin-top: 0.05rem;
   }
 
   .cds-card ul {
@@ -218,7 +219,7 @@
     text-transform: uppercase;
     letter-spacing: 0.04em;
     font-size: 0.9rem;
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.15rem;
   }
 
   img {
@@ -227,7 +228,7 @@
   }
 
   .flow-chain {
-    gap: 0.2rem 0.45rem;
+    gap: 0.18rem 0.4rem;
   }
 
   .flow-chain .flow-arrow {


### PR DESCRIPTION
## Summary
- tighten the print stylesheet for the CDS sampler so each card fits within a single page
- shrink typography spacing, padding, and image height to eliminate spillover in the exported PDF

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9be34d5388325b3fda1171bcdb10c