### PR TITLE
Adjust CDS sampler card grid breakpoints

### DIFF
--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -327,13 +327,15 @@ nav.toc a:focus-visible {
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (min-width: 820px) {
+@media (min-width: 1024px) {
+  /* Two-up layout reserved for bona fide desktop widths. */
   #sampler-content {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1700px) {
+  /* Three-up cards only show up for the mega-wide cinema displays. */
   #sampler-content {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary
- keep the sampler grid in a single column on small and tablet widths
- switch to two columns at desktop monitor sizes and reserve three columns for very wide screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c08413908325937a2e4b5003d992