### PR TITLE
Refine CDS sampler layout and reference column

### DIFF
--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -1,113 +1,118 @@
 <article id="{{ include.id }}" class="card cds-card" role="region" aria-labelledby="{{ include.id }}-title">
-  {% if include.aligns and include.aligns.size > 0 %}
-  <div class="ribbon" aria-label="Alignment tags">
-    {% for tag in include.aligns %}<span class="tag">{{ tag }}</span>{% endfor %}
-  </div>
-  {% endif %}
-
-  {% if include.img_src %}
-  <figure>
-    <img
-      src="{{ include.img_src }}"
-      alt="{{ include.img_alt | default: include.title | escape }}"
-      loading="lazy" decoding="async"
-      {% if include.img_w %}width="{{ include.img_w }}"{% else %}width="1200"{% endif %}
-      {% if include.img_h %}height="{{ include.img_h }}"{% else %}height="675"{% endif %}>
-    {% if include.figcaption %}<figcaption>{{ include.figcaption }}</figcaption>{% endif %}
-  </figure>
-  {% endif %}
-
-  <h2 id="{{ include.id }}-title">{{ include.title }}</h2>
-  {% if include.abstract %}
-  <p>
-    {% if include.abstract contains ' → ' %}
-      {% include flow-chain.html text=include.abstract class="flow-chain--paragraph" %}
-    {% else %}
-      {{ include.abstract }}
+  <div class="card-main">
+    {% if include.aligns and include.aligns.size > 0 %}
+    <div class="ribbon" aria-label="Alignment tags">
+      {% for tag in include.aligns %}<span class="tag">{{ tag }}</span>{% endfor %}
+    </div>
     {% endif %}
-  </p>
-  {% endif %}
 
-  {% if include.methods and include.methods.size > 0 %}
-  <h3>Methods &amp; Ethics</h3>
-  <ul>
-  {% for m in include.methods %}
-    <li>
-      {% if m contains ' → ' %}
-        {% include flow-chain.html text=m class="flow-chain--list" %}
-      {% else %}
-        {{ m }}
-      {% endif %}
-    </li>
-  {% endfor %}
-  </ul>
-  {% endif %}
-
-  {% if include.outcomes and include.outcomes.size > 0 %}
-  <h3>Outcomes</h3>
-  <ul>
-  {% for o in include.outcomes %}
-    <li>
-      {% if o contains ' → ' %}
-        {% include flow-chain.html text=o class="flow-chain--list" %}
-      {% else %}
-        {{ o }}
-      {% endif %}
-    </li>
-  {% endfor %}
-  </ul>
-  {% endif %}
-
-  {% if include.teach %}
-  {% assign t = include.teach %}
-  {% if t.goal or t.lab60 or t.assess %}
-  <h3>Teach with this</h3>
-  <ul>
-    {% if t.goal %}
-    <li>
-      <strong>Goal:</strong>
-      {% if t.goal contains ' → ' %}
-        {% include flow-chain.html text=t.goal class="flow-chain--inline" %}
-      {% else %}
-        {{ t.goal }}
-      {% endif %}
-    </li>
+    {% if include.img_src %}
+    <figure>
+      <img
+        src="{{ include.img_src }}"
+        alt="{{ include.img_alt | default: include.title | escape }}"
+        loading="lazy" decoding="async"
+        {% if include.img_w %}width="{{ include.img_w }}"{% else %}width="1200"{% endif %}
+        {% if include.img_h %}height="{{ include.img_h }}"{% else %}height="675"{% endif %}>
+      {% if include.figcaption %}<figcaption>{{ include.figcaption }}</figcaption>{% endif %}
+    </figure>
     {% endif %}
-    {% if t.lab60 %}
-    <li>
-      <strong>60-min lab:</strong>
-      {% if t.lab60 contains ' → ' %}
-        {% include flow-chain.html text=t.lab60 class="flow-chain--inline" %}
-      {% else %}
-        {{ t.lab60 }}
-      {% endif %}
-    </li>
-    {% endif %}
-    {% if t.assess %}
-    <li>
-      <strong>Assess:</strong>
-      {% if t.assess contains ' → ' %}
-        {% include flow-chain.html text=t.assess class="flow-chain--inline" %}
-      {% else %}
-        {{ t.assess }}
-      {% endif %}
-    </li>
-    {% endif %}
-  </ul>
-  {% endif %}
-  {% endif %}
 
-  {% if include.links and include.links.size > 0 %}
-  <ul class="links">
-    {% for l in include.links %}
-      {% assign is_ext = l.url | downcase | slice: 0, 4 %}
+    <h2 id="{{ include.id }}-title">{{ include.title }}</h2>
+    {% if include.abstract %}
+    <p>
+      {% if include.abstract contains ' → ' %}
+        {% include flow-chain.html text=include.abstract class="flow-chain--paragraph" %}
+      {% else %}
+        {{ include.abstract }}
+      {% endif %}
+    </p>
+    {% endif %}
+
+    {% if include.methods and include.methods.size > 0 %}
+    <h3>Methods &amp; Ethics</h3>
+    <ul>
+    {% for m in include.methods %}
       <li>
-        <a href="{{ l.url | default:'#' }}"
-           {% if l.disabled %}aria-disabled="true"{% elsif is_ext == 'http' %}rel="nofollow noopener"{% endif %}>
-          {{ l.label }}
-        </a>
+        {% if m contains ' → ' %}
+          {% include flow-chain.html text=m class="flow-chain--list" %}
+        {% else %}
+          {{ m }}
+        {% endif %}
       </li>
     {% endfor %}
-  </ul>
+    </ul>
+    {% endif %}
+
+    {% if include.outcomes and include.outcomes.size > 0 %}
+    <h3>Outcomes</h3>
+    <ul>
+    {% for o in include.outcomes %}
+      <li>
+        {% if o contains ' → ' %}
+          {% include flow-chain.html text=o class="flow-chain--list" %}
+        {% else %}
+          {{ o }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if include.teach %}
+    {% assign t = include.teach %}
+    {% if t.goal or t.lab60 or t.assess %}
+    <h3>Teach with this</h3>
+    <ul>
+      {% if t.goal %}
+      <li>
+        <strong>Goal:</strong>
+        {% if t.goal contains ' → ' %}
+          {% include flow-chain.html text=t.goal class="flow-chain--inline" %}
+        {% else %}
+          {{ t.goal }}
+        {% endif %}
+      </li>
+      {% endif %}
+      {% if t.lab60 %}
+      <li>
+        <strong>60-min lab:</strong>
+        {% if t.lab60 contains ' → ' %}
+          {% include flow-chain.html text=t.lab60 class="flow-chain--inline" %}
+        {% else %}
+          {{ t.lab60 }}
+        {% endif %}
+      </li>
+      {% endif %}
+      {% if t.assess %}
+      <li>
+        <strong>Assess:</strong>
+        {% if t.assess contains ' → ' %}
+          {% include flow-chain.html text=t.assess class="flow-chain--inline" %}
+        {% else %}
+          {{ t.assess }}
+        {% endif %}
+      </li>
+      {% endif %}
+    </ul>
+    {% endif %}
+    {% endif %}
+  </div>
+
+  {% if include.links and include.links.size > 0 %}
+  <aside class="card-links" aria-labelledby="{{ include.id }}-links-title">
+    <h3 id="{{ include.id }}-links-title" class="card-links-title">Reference &amp; Archive Links</h3>
+    <ul class="links">
+      {% for l in include.links %}
+        {% assign is_ext = l.url | downcase | slice: 0, 4 %}
+        <li>
+          <a href="{{ l.url | default:'#' }}"
+             {% if l.disabled %}aria-disabled="true"{% elsif is_ext == 'http' %}rel="nofollow noopener"{% endif %}>
+            {{ l.label }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </aside>
   {% endif %}
 </article>

--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -327,17 +327,10 @@ nav.toc a:focus-visible {
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1000px) {
   /* Two-up layout reserved for bona fide desktop widths. */
   #sampler-content {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1700px) {
-  /* Three-up cards only show up for the mega-wide cinema displays. */
-  #sampler-content {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -354,6 +347,61 @@ nav.toc a:focus-visible {
   box-shadow: 0 40px 65px -38px rgba(15, 23, 42, 0.5);
   overflow: hidden;
   scroll-margin-top: 6rem;
+}
+
+.cds-card .card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cds-card .card-links {
+  margin: 1.5rem 0 0;
+  padding-top: 1.35rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.cds-card .card-links-title {
+  margin: 0;
+}
+
+@media (min-width: 1280px) {
+  .cds-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(240px, 0.9fr);
+    align-items: start;
+    gap: clamp(1.5rem, 2.6vw, 2.5rem);
+  }
+
+  .cds-card .card-main {
+    grid-column: 1 / span 2;
+  }
+
+  .cds-card .card-links {
+    margin: 0;
+    padding: 0 0 0 clamp(1.25rem, 1.4vw, 1.85rem);
+    border-top: 0;
+    border-left: 1px solid rgba(148, 163, 184, 0.28);
+    align-self: stretch;
+    gap: 1rem;
+  }
+
+  .cds-card .links {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .cds-card .links li {
+    width: 100%;
+  }
+
+  .cds-card .links a {
+    justify-content: flex-start;
+    width: 100%;
+  }
 }
 
 .cds-card h2 {
@@ -485,7 +533,7 @@ nav.toc a:focus-visible {
 
 .cds-card .links {
   list-style: none;
-  margin: 1.35rem 0 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-wrap: wrap;

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -168,6 +168,10 @@
     display: none;
   }
 
+  .cds-card .card-links {
+    display: none !important;
+  }
+
   .cds-card .links {
     display: none !important;
   }


### PR DESCRIPTION
## Summary
- keep the CDS sampler grid single column until 1000px and remove the mega-wide third column of cards
- restructure each sampler card so art/content spans two columns and reference/archive links sit in a dedicated column on wide viewports
- hide the new reference column in the print stylesheet to preserve the existing PDF layout

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c5d6f3d0832592bbabb528153c08