### PR TITLE
Add Research branch with methods notebooks and cross-links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,6 +4,8 @@
   url: /art.html
 - title: Research Notebook
   url: https://bseverns.github.io/courses.html
+- title: Research
+  url: /research/
 - title: About / CV
   url: /about.html
 - title: Contact

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -51,5 +51,6 @@ updated: "2025-09-14"
       <span class="label">Sampler commit:</span>
       <code>{% if site.github and site.github.build_revision %}{{ site.github.build_revision | slice:0,7 }}{% else %}local{% endif %}</code>
     </p>
+    <p class="methods-note"><em><strong>Methods live in <a href="/research/">Research</a>.</strong></em></p>
   </footer>
 </div>

--- a/research/facetimes-assumptions.md
+++ b/research/facetimes-assumptions.md
@@ -1,0 +1,30 @@
+---
+title: "faceTimes — Assumption Ledger"
+layout: default
+permalink: /research/facetimes-assumptions/
+tags: ["methods","assumption-ledger","facetimes","teaching"]
+---
+
+# faceTimes — Assumption Ledger
+
+What we’re assuming, why it matters, how we mitigate.
+
+> **Canonical source:** `TODO: add GitHub URL to ASSUMPTIONS.md`  
+> **Last synced:** `TODO: YYYY-MM-DD`
+
+## Ledger (excerpt)
+| ID | Assumption | Risk | Mitigation | Evidence/Link |
+|----|------------|------|------------|---------------|
+| A-01 | On-device detection only | Drift toward network calls | Lock builds; lint CI for net calls | `TODO: link test` |
+| A-02 | Delete by default | Accidental retention | Confirm UI + timeout purge | `TODO: link UI test` |
+| A-03 | No identification | Feature creep | Scope statement in README | `TODO: link README` |
+
+`TODO: Embed full ledger once uploaded.`
+
+## Logic diagrams
+`TODO: Add diagrams (mermaid or PNG)`  
+
+## Teaching sketch
+- Students audit assumptions
+- Convert one mitigation into a test
+- Reflect on where ethics meet engineering

--- a/research/index.md
+++ b/research/index.md
@@ -1,0 +1,18 @@
+---
+title: "Research"
+nav_title: "Research"
+layout: default
+permalink: /research/
+summary: "Methods that make claims legible."
+---
+
+# Research
+
+**Methods that make claims legible.**  
+This notebook publishes the scaffolds behind the sampler—Privacy & Ethics, assumption ledgers, latency labs, and other accountable methods. Everything here is reproducible: how we sense, measure, and mitigate is part of the work itself.
+
+## Pages
+- [Privacy & Ethics](/research/privacy-ethics/)
+- [faceTimes — Assumption Ledger](/research/facetimes-assumptions/)
+- [MN42 — Latency Characterization Lab](/research/mn42-latency-lab/)
+- <!-- Optional: [Glitch Geometry — Methods](/research/glitch-geometry-methods/) -->

--- a/research/mn42-latency-lab.md
+++ b/research/mn42-latency-lab.md
@@ -1,0 +1,28 @@
+---
+title: "MN42 — Latency Characterization Lab"
+layout: default
+permalink: /research/mn42-latency-lab/
+tags: ["methods","mn42","measurement","latency"]
+---
+
+# MN42 — Latency Characterization Lab
+
+Latency is a feeling before it is a number; we measure so students can reason about mappings, not mythologize them.
+
+## Method (replicable)
+- Loopback rig: `TODO: describe interface + cabling`
+- Buffer sizes & sample rates: `TODO: enumerate`
+- Trial counts & stats: `TODO: specify`
+- Script(s): `TODO: link`
+
+## Results (snapshot)
+![Round-trip latency plots — baseline vs tuned](/assets/images/mn42-latency-baseline.png "Round-trip latency plots — baseline vs tuned")
+*Alt:* Round-trip latency plots showing baseline and tuned configurations.  
+`TODO: replace with real chart`
+
+### Interpretation (2–3 sentences per plot)
+- `TODO: Add notes`
+
+## Notes for class
+- Prompts, pitfalls, follow-ups
+- How to reproduce on student machines

--- a/research/privacy-ethics.md
+++ b/research/privacy-ethics.md
@@ -1,0 +1,23 @@
+---
+title: "Privacy & Ethics (v0.x)"
+layout: default
+permalink: /research/privacy-ethics/
+tags: ["methods","ethics","privacy","teaching"]
+---
+
+# Privacy & Ethics
+
+We treat sensing as an **agreement**, not a default. This page mirrors the canonical document in the code repositories and is kept in sync at review milestones.
+
+> **Canonical source:** `TODO: add GitHub URL to PRIVACY_ETHICS.md`  
+> **Last synced:** `TODO: YYYY-MM-DD`
+
+## Principles (snapshot)
+- Opt-in by design
+- Data minimization, local computation first
+- Transparent interfaces (“Show”, “Delete”, “Save with intent”)
+- Classroom/public signage and accessible language
+- Logs, assumption ledgers, and reproducible mitigation steps
+
+## For reviewers
+Downloadable PDF: `TODO: add /assets/pdfs/privacy-ethics-v0x.pdf`


### PR DESCRIPTION
## Summary
- establish a Research landing page with Privacy & Ethics, faceTimes assumption ledger, and MN42 latency lab placeholders
- add a Research link to the global navigation and point the sampler footer at the new branch

## Testing
- not run (jekyll build not run)

---

### POST-RUN CHECKLIST
- [ ] Replace TODO: links to canonical docs once uploaded
- [ ] Swap placeholder plot with real MN42 charts
- [ ] Add diagrams/figures to faceTimes ledger page
- [ ] Verify Sampler six images have descriptive alt text

------
https://chatgpt.com/codex/tasks/task_e_68c9faafd17c832585340ce3111ce7a6