### PR TITLE
Update course page content and add research link from art page

### DIFF
--- a/art.html
+++ b/art.html
@@ -114,6 +114,17 @@
   </a>
 </li>
 
+<!--Research hub-->
+<li class="grid-item" data-jkit="[show:delay=3800;speed=500;animation=fade]">
+  <img loading="lazy" src="img/front/research-placeholder.svg" alt="Research portal placeholder graphic">
+  <a href="/research/" target="_blank" rel="noopener">
+    <div class="grid-hover">
+      <h1>Research</h1>
+      <p>Methods, instruments, and receipts.</p>
+    </div>
+  </a>
+</li>
+
 <!--Poetry is what happens when nothing else can-->
 <li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
   <iframe src="https://player.vimeo.com/video/118443299" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/courses.html
+++ b/courses.html
@@ -56,8 +56,13 @@
   <div class="content">
     <div class="text-intro">
       <h1>Academic Portfolio</h1>
-      <p>Syllabi and assorted classroom experiments are simmering here. Check back while the dust settles.</p>
-      <p>Raid the <a href="/critical-digital-studies-sampler/">Critical Digital Studies Sampler</a> for the most-recently well-documented builds-in-progress or jump straight to the <a href="https://github.com/bseverns/Syllabus">Syllabus repo</a> for the raw goods.</p>
+      <p>Syllabi and assorted classroom experiments are simmering here. I'm keeping this corner honest by only listing the builds that actually live on this server.</p>
+      <ul class="syllabus-list">
+        <li><a href="/teaching/creative-coding/">Creative Coding 101</a> — a first pass at generative sketching, p5.js riffs, and critique etiquette.</li>
+        <li><a href="/teaching/critical-making/">Critical Making — Day One</a> — solder fumes, theory jams, and reflective documentation from hour one.</li>
+        <li><a href="/teaching/media2-mtn/">MCAD Media 2 — MTN Broadcast</a> — collaborative broadcast production with ethics, consent, and process logs on full display.</li>
+      </ul>
+      <p>Need the deep cuts or version history? Raid my <a href="https://github.com/bseverns">GitHub repos</a> for syllabi source files, starter code, and other workshop debris.</p>
     </div>
 
     <!--

--- a/img/front/research-placeholder.svg
+++ b/img/front/research-placeholder.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Research portal placeholder graphic</title>
+  <desc id="desc">Abstract gradient background with bold text that reads Research Notes.</desc>
+  <defs>
+    <linearGradient id="punkGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#101010" />
+      <stop offset="50%" stop-color="#2b8a9a" />
+      <stop offset="100%" stop-color="#f12f6b" />
+    </linearGradient>
+    <linearGradient id="grid" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.12" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+    <pattern id="mesh" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M0 0h40v40H0z" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="2" />
+    </pattern>
+  </defs>
+  <rect width="800" height="600" fill="url(#punkGradient)" />
+  <rect width="800" height="600" fill="url(#mesh)" />
+  <rect y="320" width="800" height="120" fill="url(#grid)" />
+  <text x="50%" y="45%" font-family="'Raleway', 'Helvetica Neue', Arial, sans-serif" font-size="80" text-anchor="middle" fill="#ffffff" font-weight="800" letter-spacing="12">RESEARCH</text>
+  <text x="50%" y="60%" font-family="'Raleway', 'Helvetica Neue', Arial, sans-serif" font-size="32" text-anchor="middle" fill="#fefefe" font-weight="500" letter-spacing="8">FIELD NOTES</text>
+</svg>


### PR DESCRIPTION
## Summary
- refresh the courses landing copy so it only cites the syllabi hosted on the site and points visitors to GitHub for source material
- add a research tile to the art grid so the research hub is accessible beside the CONTEXT link
- create a lightweight research placeholder graphic for the new tile

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ca0e8e7f108325b3cd4e5e79715974