### PR TITLE
Normalize first-person voice in research docs

### DIFF
--- a/PRIVACY_ETHICS.md
+++ b/PRIVACY_ETHICS.md
@@ -9,17 +9,17 @@
 ---
 
 ## 0. Plain‑Language Summary (TL;DR)
-- **Dignity over data.** We only collect what we need to make a thing work, and only *with explicit, informed consent*.
+- **Dignity over data.** I only collect what’s needed to make a thing work, and only *with explicit, informed consent*.
 - **Local first, deletion by default.** Process on‑device when possible. Store as little as possible. “Delete now” is always one click away.
 - **Open by design, not exploitative.** Code and documentation prefer free/libre licenses. Sharing knowledge is not a license to extract people.
 - **Care for minors and communities.** Extra protections for youth. Harm prevention beats novelty.
-- **Transparent practice.** We publish an assumption ledger, data‑flows, known risks, and change logs.
+- **Transparent practice.** I publish an assumption ledger, data‑flows, known risks, and change logs.
 - **Accountable and reversible.** Consent can be revoked, data can be erased, decisions can be appealed.
 
 ---
 
 ## 1. North Star
-We build tools, scenes, and learning environments where **other people create**. Our ethics follow that purpose: **reduce harm, increase agency, share knowledge,** and design systems that **support equitable participation**. We align with the **free software movement**—*free as in freedom to study, modify, share, and use*—and we operate in the spirit of **Kent’s 10 rules** as a craft ethos of clarity, humility, and responsibility in making. 
+I build tools, scenes, and learning environments where **other people create**. My ethics follow that purpose: **reduce harm, increase agency, share knowledge,** and design systems that **support equitable participation**. I align with the **free software movement**—*free as in freedom to study, modify, share, and use*—and I operate in the spirit of **Kent’s 10 rules** as a craft ethos of clarity, humility, and responsibility in making.
 
 ---
 
@@ -34,14 +34,14 @@ This statement covers:
 
 ## 3. Principles
 1. **Human dignity is inviolable.** People are not datasets. No biometric identification or surveillance by default. Detection‑only when possible.  
-2. **Equity is a system requirement.** We design for the margins first and audit for disparate impacts.  
+2. **Equity is a system requirement.** I design for the margins first and audit for disparate impacts.
 3. **Consent is an interface.** Opt‑in, affirmative, revocable, time‑bounded, and contextual. Consent UX is plain‑language and visible.  
-4. **Data minimization.** If we don’t need it, we don’t collect it. If we must collect it, we keep it briefly and securely.  
+4. **Data minimization.** If I don’t need it, I don’t collect it. If I must collect it, I keep it short-lived and secure.
 5. **Local first.** Prefer on‑device processing with no network calls.  
 6. **Transparency and legibility.** Publish assumption ledgers, data‑flow diagrams, and change logs.  
 7. **Right to inspect, correct, and erase.** Participants can see what exists about them, fix it, or remove it—fast.  
-8. **Open knowledge, not open people.** We release *code, methods, and documentation* under free/libre licenses while *protecting personal data*.  
-9. **Accountability.** Clear roles, audit trails, and incident response. When harm happens, we repair where possible and learn in public.  
+8. **Open knowledge, not open people.** I release *code, methods, and documentation* under free/libre licenses while *protecting personal data*.
+9. **Accountability.** Clear roles, audit trails, and incident response. When harm happens, I repair where possible and learn in public.
 10. **Proportionality & necessity.** Fancy isn’t a justification. Risk must be proportionate to purpose.
 
 ---
@@ -56,12 +56,12 @@ This statement covers:
 ---
 
 ## 5. Data Practice
-### 5.1 What we avoid
+### 5.1 What I avoid
 - Facial **identification** or **recognition**; emotion inference; demographic inference.  
 - Passive, undisclosed logging (no shadow telemetry).  
 - Cross‑context tracking; ad tech; data broker sharing.
 
-### 5.2 What we may collect (case‑by‑case)
+### 5.2 What I may collect (case‑by‑case)
 - **Ephemeral sensor data** required for live functionality (e.g., audio levels, detection bounding boxes) retained **in RAM** only.  
 - **Operational logs** necessary for stability and safety—anonymized, minimized, and **rotated quickly**.  
 - **Explicit submissions** from participants (e.g., saved images, consent forms) stored only with clear time limits.
@@ -107,7 +107,7 @@ This statement covers:
 - **Documentation & Curriculum:** Prefer **CC BY‑SA 4.0**.  
 - **Media Assets:** Prefer **CC BY‑NC** (or more permissive if participants agree).  
 - **Contributor Terms:** Contributions are accepted under the same licenses; contributors affirm they have rights to contribute; no CLA surprise grabs.  
-- **Ethical Use Rider:** Licenses are free/libre; we additionally publish norms discouraging use in surveillance, discrimination, or state/corporate harm—even when license text permits. We name those harms plainly.
+- **Ethical Use Rider:** Licenses are free/libre; I additionally publish norms discouraging use in surveillance, discrimination, or state/corporate harm—even when license text permits. I name those harms plainly.
 
 ---
 
@@ -121,7 +121,7 @@ This statement covers:
   - Notify affected participants when relevant.
   - Publish a post‑mortem with fixes and timelines.
 
-- **Appeals & Remedies:** Participants can request review of decisions (e.g., takedowns, denials). We prioritize repairing harm over defending reputation.
+- **Appeals & Remedies:** Participants can request review of decisions (e.g., takedowns, denials). I prioritize repairing harm over defending reputation.
 
 ---
 
@@ -148,9 +148,9 @@ Each project includes a `PRIVACY-ADDENDUM.md` with:
 ---
 
 ## 12. Known Limits & Commitments
-- We cannot guarantee absolute security, but we commit to **minimization, encryption, and rapid response**.  
-- We will sometimes choose **less capable** technology to reduce risk.  
-- When constraints force compromise, we will **name the trade‑offs** and **invite critique**.
+- I cannot guarantee absolute security, but I commit to **minimization, encryption, and rapid response**.
+- I will sometimes choose **less capable** technology to reduce risk.
+- When constraints force compromise, I will **name the trade‑offs** and **invite critique**.
 
 ---
 

--- a/assets/images/cds/README.md
+++ b/assets/images/cds/README.md
@@ -12,4 +12,4 @@ Drop in your own visuals—stick to the same filenames so the card markup doesn'
 2. Overwrite the matching `.svg` file here with your asset (keep the name).
 3. Commit, run `python tools/lint_sampler.py`, and roll on.
 
-Yes, it's a little bare-bones, but that's the point—we're shipping scaffolding, not secrets.
+Yes, it's a little bare-bones, but that's the point—I’m shipping scaffolding, not secrets.

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -20,7 +20,7 @@ updated: "2025-09-14"
       </div>
       <p class="lede">I pair critical inquiry with hands-on digital practice—playful rigor: {% include flow-chain.html text="build → perform (play) → document → iterate" class="flow-chain--lede" %}.</p>
       <p>Working systems-first, I make technical and ethical layers legible so students can audit and extend them. This sampler foregrounds digital literacy within questions of justice, representation, and civic engagement, preparing makers to treat media as civic instruments.</p>
-       <p class="privacy-note">Every project here rides inside our <a href="{{ 'https://github.com/bseverns/bseverns.github.io/blob/main/PRIVACY_ETHICS.md' | relative_url }}">Privacy &amp; Ethics Statement (v0.1)</a>—dignity over data, consent as interface, local-first processing, and the right to erase. Each project adds its own assumption ledger to tighten those guardrails, never loosen them.</p>
+       <p class="privacy-note">Every project here rides inside my <a href="{{ 'https://github.com/bseverns/bseverns.github.io/blob/main/PRIVACY_ETHICS.md' | relative_url }}">Privacy &amp; Ethics Statement (v0.1)</a>—dignity over data, consent as interface, local-first processing, and the right to erase. Each project adds its own assumption ledger to tighten those guardrails, never loosen them.</p>
     </div>
     <aside class="service">
       <h2>Service &amp; Stewardship</h2>

--- a/research/facetimes-assumptions.md
+++ b/research/facetimes-assumptions.md
@@ -7,7 +7,7 @@ tags: ["methods","assumption-ledger","facetimes","teaching"]
 
 # faceTimes — Assumption Ledger
 
-What we’re assuming, why it matters, how we mitigate.
+What I’m assuming, why it matters, how I mitigate.
 
 > **Canonical source:** `TODO: add GitHub URL to ASSUMPTIONS.md`  
 > **Last synced:** `TODO: YYYY-MM-DD`

--- a/research/index.md
+++ b/research/index.md
@@ -9,7 +9,7 @@ summary: "Methods that make claims legible."
 # Research
 
 **Methods that make claims legible.**  
-This notebook publishes the scaffolds behind the sampler—Privacy & Ethics, assumption ledgers, latency labs, and other accountable methods. Everything here is reproducible: how we sense, measure, and mitigate is part of the work itself.
+This notebook publishes the scaffolds behind the sampler—Privacy & Ethics, assumption ledgers, latency labs, and other accountable methods. Everything here is reproducible: how I sense, measure, and mitigate is part of the work itself.
 
 ## Pages
 - [Privacy & Ethics](/research/privacy-ethics/)

--- a/research/mn42-latency-lab.md
+++ b/research/mn42-latency-lab.md
@@ -7,7 +7,7 @@ tags: ["methods","mn42","measurement","latency"]
 
 # MN42 — Latency Characterization Lab
 
-Latency is a feeling before it is a number; we measure so students can reason about mappings, not mythologize them.
+Latency is a feeling before it is a number; I measure so students can reason about mappings, not mythologize them.
 
 ## Method (replicable)
 - Loopback rig: `TODO: describe interface + cabling`

--- a/research/privacy-ethics.md
+++ b/research/privacy-ethics.md
@@ -7,7 +7,7 @@ tags: ["methods","ethics","privacy","teaching"]
 
 # Privacy & Ethics
 
-We treat sensing as an **agreement**, not a default. This page mirrors the canonical document in the code repositories and is kept in sync at review milestones.
+I treat sensing as an **agreement**, not a default. This page mirrors the canonical document in the code repositories and is kept in sync at review milestones.
 
 > **Canonical source:** `TODO: add GitHub URL to PRIVACY_ETHICS.md`  
 > **Last synced:** `TODO: YYYY-MM-DD`


### PR DESCRIPTION
## Summary
- shift research and ethics pages to first-person singular voice where they describe my authored methods and commitments
- align sampler and asset notes with the singular voice for consistency

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0250ff288325b58f80febe5e5e7e