### PR TITLE
Update course descriptions on courses page

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -58,11 +58,11 @@
       <h1>Academic Portfolio</h1>
       <p>Syllabi and assorted classroom experiments are simmering here. I'm keeping this corner honest by only listing the builds that actually live on this server.</p>
       <ul class="syllabus-list">
-        <li><a href="/text/SP23_FDN131102_Foundation_ Media1_Severns.docx/">MCAD Foundation: Media 1</a> — a first pass at generative sketching, p5.js riffs, and critique etiquette.</li>
-        <li><a href="/text/SP23_FDN131203_Foundation_ Media2_Severns.docx/">MCAD Foundation: Media 2</a> — solder fumes, theory jams, and reflective documentation from hour one.</li>
-        <li><a href="/text/SP20_WMM308501_ExperimentalSoundDesign_Severns.docx/">MCAD Experimental Sound Design</a> — collaborative broadcast production with ethics, consent, and process logs on full display.</li>
-        <li><a href="/text/SP19_FDN141105_IdeationandProcess_Severns.docx">MCAD Foundation: Media 1</a> — a first pass at generative sketching, p5.js riffs, and critique etiquette.</li>
-        <li><a href="/text/SP19_SC308201_SculptureStudio_ Arduino_Severns.docx">MCAD Foundation: Media 1</a> — a first pass at generative sketching, p5.js riffs, and critique etiquette.</li>
+        <li><a href="/text/SP23_FDN131102_Foundation_ Media1_Severns.docx/">MCAD Foundation: Media 1</a> — a guided tour of MCAD's digital resources with hands-on work in video, sound, photography, and the critical language to talk about them.</li>
+        <li><a href="/text/SP23_FDN131203_Foundation_ Media2_Severns.docx/">MCAD Foundation: Media 2</a> — sustained experiments in observation, recording, editing, and multimedia storytelling that push beyond the Media 1 toolkit.</li>
+        <li><a href="/text/SP20_WMM308501_ExperimentalSoundDesign_Severns.docx/">MCAD Experimental Sound Design</a> — a hybrid workshop on making noise: capture audio, build performance rigs, and tinker with both DIY and high-tech sound manipulation.</li>
+        <li><a href="/text/SP19_FDN141105_IdeationandProcess_Severns.docx">MCAD Ideation and Process</a> — frameworks for developing ideas, charting process, and producing short projects with collaborative and solo critiques.</li>
+        <li><a href="/text/SP19_SC308201_SculptureStudio_ Arduino_Severns.docx">MCAD Sculpture Studio: Arduino</a> — open-source circuitry meets sculpture in a course on actuated objects, responsive installations, and communal code-sharing.</li>
       </ul>
       <p>Need the deep cuts or version history? Raid my <a href="https://github.com/bseverns">GitHub repos</a> for syllabi source files, starter code, and other workshop debris.</p>
     </div>


### PR DESCRIPTION
## Summary
- refresh the course descriptions on `courses.html` to match the focus and outcomes listed in the linked syllabi
- correct duplicate course titles so each syllabus link has distinct copy reflecting its course

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0a6880c48325b0108744cd2abe72