### PR TITLE
Simplify CDS sampler layout breakpoints

### DIFF
--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -248,7 +248,7 @@ aside.service p {
   gap: clamp(2rem, 5vw, 3rem);
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 900px) {
   .sampler-main {
     grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
     align-items: start;
@@ -264,7 +264,7 @@ nav.toc {
   padding: clamp(1rem, 2.5vw, 1.6rem);
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 900px) {
   nav.toc {
     position: sticky;
     top: 2rem;
@@ -288,7 +288,7 @@ nav.toc ul {
   gap: 0.75rem;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 900px) {
   nav.toc ul {
     flex-direction: column;
   }
@@ -327,8 +327,18 @@ nav.toc a:focus-visible {
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (min-width: 1000px) {
-  /* Two-up layout reserved for bona fide desktop widths. */
+@media (min-width: 900px) {
+  #sampler-content {
+    grid-column: 2 / -1;
+  }
+}
+
+@media (min-width: 1200px) {
+  /* Three column layout: Projects list + two-up grid */
+  .sampler-main {
+    grid-template-columns: minmax(220px, 260px) repeat(2, minmax(0, 1fr));
+  }
+
   #sampler-content {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary
- tighten the CDS sampler layout to three responsive modes: single-column, two-column, and a three-column layout with the Projects & Methods nav alongside a two-up grid
- update the Projects & Methods navigation styles so the column stack matches the simplified breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0c89225483258e70105c297dd782