### PR TITLE
Limit CDS sampler grid to two columns and enlarge card media

### DIFF
--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -12,8 +12,8 @@
         src="{{ include.img_src }}"
         alt="{{ include.img_alt | default: include.title | escape }}"
         loading="lazy" decoding="async"
-        {% if include.img_w %}width="{{ include.img_w }}"{% else %}width="1200"{% endif %}
-        {% if include.img_h %}height="{{ include.img_h }}"{% else %}height="675"{% endif %}>
+        {% if include.img_w %}width="{{ include.img_w }}"{% else %}width="2500"{% endif %}
+        {% if include.img_h %}height="{{ include.img_h }}"{% else %}height="1407"{% endif %}>
       {% if include.figcaption %}<figcaption>{{ include.figcaption }}</figcaption>{% endif %}
     </figure>
     {% endif %}

--- a/assets/css/cds-sampler.css
+++ b/assets/css/cds-sampler.css
@@ -26,7 +26,7 @@ main#content {
 }
 
 .cds-sampler {
-  max-width: min(1320px, 96vw);
+  max-width: min(2500px, 96vw);
   margin: clamp(1.5rem, 4vw, 3rem) auto clamp(3rem, 8vw, 5rem);
   padding: clamp(2.5rem, 4vw, 3.75rem);
   background: rgba(255, 255, 255, 0.94);
@@ -250,7 +250,7 @@ aside.service p {
 
 @media (min-width: 900px) {
   .sampler-main {
-    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
     align-items: start;
   }
 }
@@ -334,13 +334,12 @@ nav.toc a:focus-visible {
 }
 
 @media (min-width: 1200px) {
-  /* Three column layout: Projects list + two-up grid */
   .sampler-main {
-    grid-template-columns: minmax(220px, 260px) repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
   }
 
   #sampler-content {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the sampler wrapper so the layout can stretch up to 2500px wide
- cap the sampler layout at two columns so only one column holds portfolio cards
- bump the default card image dimensions to allow responsive growth up to 2500px

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb129971108325944a61448f1639cd