### PR TITLE
Fix latency lab link formatting in CDS sampler

### DIFF
--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -52,7 +52,7 @@
         {% if o contains ' → ' %}
           {% include flow-chain.html text=o class="flow-chain--list" %}
         {% else %}
-          {{ o }}
+          {{ o | markdownify | replace: '<p>', '' | replace: '</p>', '' }}
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- render CDS sampler outcome copy with markdown so inline links stay clickable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb1d4b14b0832582df33cc439a82e6