### PR TITLE
Improve About page content structure

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,77 +57,101 @@
     <div class="text-intro">
       <h1>About/CV</h1>
       <div class="one-column">
-        <p>| Artist | Educator | Strategist |</br>| Designer | Developer | Musician |</p>
+        <p>| Artist | Educator | Strategist |</p>
+        <p>| Designer | Developer | Musician |</p>
         <img src="img/logo/self_about.jpg" alt="self portrait of Ben Severns">
       </div>
       <div class="two-column">
-        <h1>About</h1>
-        <p>Ben Severns is an interdisciplinary artist whose studio work is centered around the need for some way out of the theoretically evitable cycle of Spectacular distraction and self-involvement that permeates contemporary life.
-          </br></br>Shifting media as it suits the project, his work has been exhibited throughout the United States, including at Boston University, the Institute of Contemporary Art at the Maine College of Art, the Science Museum of Minnesota, the
-          Minneapolis Institute of Art, Public Functionary Gallery, the Walker Art Center, and others.
-          </br></br>His work in community development and social justice organizations has seen him act as a project manager, organizer, and educator. His work is held in private collections in the United States and Brazil.</p>
+        <h2>About</h2>
+        <p>Ben Severns is an interdisciplinary artist whose studio work is centered around the need for some way out of the theoretically evitable cycle of Spectacular distraction and self-involvement that permeates contemporary life.</p>
+        <p>Shifting media as it suits the project, his work has been exhibited throughout the United States, including at Boston University, the Institute of Contemporary Art at the Maine College of Art, the Science Museum of Minnesota, the Minneapolis Institute of Art, Public Functionary Gallery, the Walker Art Center, and others.</p>
+        <p>His work in community development and social justice organizations has seen him act as a project manager, organizer, and educator. His work is held in private collections in the United States and Brazil.</p>
       </div>
     </div>
-<div class="clear"></div>
+    <div class="clear"></div>
     <div class="text-intro" id="site-type">
       <h2>CV</h2>
-      <p><stong>Appointments:</stong></br>
-        Education Equipment & Services Lead - createMPLS (Minneapolis, MN) - present</br>
-        Adjunct Faculty - Minneapolis College of Art & Design (Minneapolis, MN) - 2013-2023</br>
-        Adjunct Facult - Augsburg University (Minneapolis, MN) - 2015-2022</br>
-        Media Arts Instructor (9-12) - PiM Arts High School (Eden Prarie, MN) - 2018-2020
-        <strong>Education:</strong></br>
-        Maine College of Art, Portland, ME</br>
-        <strong>Master of Fine Arts:</strong> Studio Art</br>
-        Minneapolis College of Art and Design, Minneapolis, MN</br>
-        <strong>Bachelor of Fine Arts:</strong> Fine Arts Studio</br></br>
-        <strong>Selected Exhibitions:</strong></br>
-        2020 Light Spa: Night Walk, East St. Paul, MN</br>
-        2019 Energy, Made Here, Minneapolis, MN</br>
-        2018 Wolfpack, Arcana Masonic Lodge, Minneapolis, MN</br>
-        2017 Out of the Blue, Greylight Projects, Hoensbroek, DE</br>
-        2017 Future, Made Here, Minneapolis, MN</br>
-        2015 Body and Machine, Northrup King Gallery, Minneapolis, MN</br>
-        2014 P.O.E.P.O.L., Good CARma, Minneapolis, MN</br>
-        2014 Faster Than Fast, The Bank, Knoxville, IA</br>
-        2014 Make it Move, Northrup King Gallery, Minneapolis, MN</br>
-        2013 Bright Lights, Public Functionary, Minneapolis, MN</br>
-        2013 Boston Young Contemporaries, Boston University, Boston, MA</br>
-        2013 You and I, alone, Geno’s Rock Club, Portland, ME</br>
-        2013 Master’s Thesis Exhibition, Maine College of Art, Portland, ME</br>
-        2012 MFA Retrospective, Maine College of Art, Portland, ME</br>
-        2012 Ben’s Black Flag, The Blue Ox, Portland, ME</br>
-        2012 Detritus, Octopi Gallery, Portland, ME</br>
-        2009 Bury, Art of This Gallery, Minneapolis, MN</br></br>
-        <strong>Curated:</strong></br>
-        2016 DANGER, Arcana Mason Lodge, Minneapolis, MN</br>
-        2011 MFA Retrospective, Maine College of Art, Portland, ME (with P. Nadal, and T.J. Young)</br>
-        2010 No Longer, Fallout Urban Art Center, Minneapolis, MN</br>
-        2010 In The Heart, To Soho, Minneapolis, MN (with N. Osborn, and M. Seagren)</br></br>
-        <strong>Awards:</strong></br>
-        2013 Young Family Scholarship, Maine College of Art, Portland, ME</br>
-        2012 Presidential Graduate Grant, Maine College of Art, Portland, ME</br>
-        2011 Presidential Graduate Grant, Maine College of Art, Portland, ME</br>
-        SELECTED PROJECTS (TOOLS FOR OTHERS)
-• MOARkNOBS-42 — open-hardware MIDI controller + teaching platform (Teensy 4.x, custom PCBs, firmware/PlatformIO); course backbone for maker studios
-• FaceTimes — privacy-first, opt-in face-detection capture with on-screen data-flow map, save/erase controls, and an avatar-generation path
-• Jetson Soundscape — multi-timbral AV pipeline (video→character/timbre features→20-voice industrial texture), Syphon-friendly for live mixes
-• Print-Farm Modernization — Marlin/BLTouch setups, SKR Mini swaps, Stratasys Mojo/UPrint conversions, shop SOPs for youth labs
-• AE Modular Utilities — custom bus/power & hand-made cabling for resilient student rigs
-• Teensy DSP Unit — low-pass, delay/feedback, controllable “dirt,” stereoization, seeded randomness, and LED chaos meter for performance pedagogy
-
-SELECTED DISCOGRAPHY (as B_S_)
-• Better Days Ahead • Slow Down • SDEP • SS-LW • NDMA2 • No More Noise Today
-(Industrial/noise: long-form collages, tape hiss, circuit-bent and digital signal chains.)
-
-TECHNICAL SKILLS
-• Code: Processing/Java, p5.js/JS, Python, C/C++ (Arduino/Teensy), PlatformIO, Git
-• Audio: DSP fundamentals (filters, delay, feedback), Reaper/BandLab workflows, MIDI
-• Fabrication: 3D printing (Cura, Marlin tuning), laser/CNC, MIG, electronics, soldering
-• Platforms: Teensy, Arduino, Raspberry Pi, NVIDIA Jetson, TouchDesigner, GitHub
-• Pedagogy: K–12 to college; inclusive, project-based learning; curriculum build-outs; shop safety; documentation as a creative act
-
-      </p>
+      <section>
+        <h3>Appointments</h3>
+        <ul>
+          <li>Education Equipment &amp; Services Lead — createMPLS (Minneapolis, MN) — Present</li>
+          <li>Adjunct Faculty — Minneapolis College of Art &amp; Design (Minneapolis, MN) — 2013–2023</li>
+          <li>Adjunct Faculty — Augsburg University (Minneapolis, MN) — 2015–2022</li>
+          <li>Media Arts Instructor (9–12) — PiM Arts High School (Eden Prairie, MN) — 2018–2020</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Education</h3>
+        <ul>
+          <li>Maine College of Art — Portland, ME — <strong>Master of Fine Arts:</strong> Studio Art</li>
+          <li>Minneapolis College of Art and Design — Minneapolis, MN — <strong>Bachelor of Fine Arts:</strong> Fine Arts Studio</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Selected Exhibitions</h3>
+        <ul>
+          <li>2020 — Light Spa: Night Walk, East St. Paul, MN</li>
+          <li>2019 — Energy, Made Here, Minneapolis, MN</li>
+          <li>2018 — Wolfpack, Arcana Masonic Lodge, Minneapolis, MN</li>
+          <li>2017 — Out of the Blue, Greylight Projects, Hoensbroek, DE</li>
+          <li>2017 — Future, Made Here, Minneapolis, MN</li>
+          <li>2015 — Body and Machine, Northrup King Gallery, Minneapolis, MN</li>
+          <li>2014 — P.O.E.P.O.L., Good CARma, Minneapolis, MN</li>
+          <li>2014 — Faster Than Fast, The Bank, Knoxville, IA</li>
+          <li>2014 — Make it Move, Northrup King Gallery, Minneapolis, MN</li>
+          <li>2013 — Bright Lights, Public Functionary, Minneapolis, MN</li>
+          <li>2013 — Boston Young Contemporaries, Boston University, Boston, MA</li>
+          <li>2013 — You and I, Alone, Geno’s Rock Club, Portland, ME</li>
+          <li>2013 — Master’s Thesis Exhibition, Maine College of Art, Portland, ME</li>
+          <li>2012 — MFA Retrospective, Maine College of Art, Portland, ME</li>
+          <li>2012 — Ben’s Black Flag, The Blue Ox, Portland, ME</li>
+          <li>2012 — Detritus, Octopi Gallery, Portland, ME</li>
+          <li>2009 — Bury, Art of This Gallery, Minneapolis, MN</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Curated</h3>
+        <ul>
+          <li>2016 — DANGER, Arcana Mason Lodge, Minneapolis, MN</li>
+          <li>2011 — MFA Retrospective, Maine College of Art, Portland, ME (with P. Nadal and T.J. Young)</li>
+          <li>2010 — No Longer, Fallout Urban Art Center, Minneapolis, MN</li>
+          <li>2010 — In The Heart, To Soho, Minneapolis, MN (with N. Osborn and M. Seagren)</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Awards</h3>
+        <ul>
+          <li>2013 — Young Family Scholarship, Maine College of Art, Portland, ME</li>
+          <li>2012 — Presidential Graduate Grant, Maine College of Art, Portland, ME</li>
+          <li>2011 — Presidential Graduate Grant, Maine College of Art, Portland, ME</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Selected Projects (Tools for Others)</h3>
+        <ul>
+          <li>MOARkNOBS-42 — Open-hardware MIDI controller and teaching platform (Teensy 4.x, custom PCBs, firmware/PlatformIO); course backbone for maker studios</li>
+          <li>FaceTimes — Privacy-first, opt-in face-detection capture with on-screen data-flow map, save/erase controls, and an avatar-generation path</li>
+          <li>Jetson Soundscape — Multi-timbral AV pipeline (video → character/timbre features → 20-voice industrial texture), Syphon-friendly for live mixes</li>
+          <li>Print-Farm Modernization — Marlin/BLTouch setups, SKR Mini swaps, Stratasys Mojo/UPrint conversions, shop SOPs for youth labs</li>
+          <li>AE Modular Utilities — Custom bus/power and hand-made cabling for resilient student rigs</li>
+          <li>Teensy DSP Unit — Low-pass, delay/feedback, controllable “dirt,” stereoization, seeded randomness, and LED chaos meter for performance pedagogy</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Selected Discography (as B_S_)</h3>
+        <p>Better Days Ahead · Slow Down · SDEP · SS-LW · NDMA2 · No More Noise Today</p>
+        <p class="description">Industrial/noise: long-form collages, tape hiss, circuit-bent and digital signal chains.</p>
+      </section>
+      <section>
+        <h3>Technical Skills</h3>
+        <ul>
+          <li><strong>Code:</strong> Processing/Java, p5.js/JS, Python, C/C++ (Arduino/Teensy), PlatformIO, Git</li>
+          <li><strong>Audio:</strong> DSP fundamentals (filters, delay, feedback), Reaper/BandLab workflows, MIDI</li>
+          <li><strong>Fabrication:</strong> 3D printing (Cura, Marlin tuning), laser/CNC, MIG, electronics, soldering</li>
+          <li><strong>Platforms:</strong> Teensy, Arduino, Raspberry Pi, NVIDIA Jetson, TouchDesigner, GitHub</li>
+          <li><strong>Pedagogy:</strong> K–12 to college; inclusive, project-based learning; curriculum build-outs; shop safety; documentation as a creative act</li>
+        </ul>
+      </section>
     </div>
 
     <!--Footer-->


### PR DESCRIPTION
## Summary
- replace line-break-only formatting on the About page with paragraphs for cleaner flow
- restructure the CV content into semantic sections and lists for appointments, education, exhibitions, and more
- tidy layout markup to ensure proper spacing between the intro and CV sections

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc7bc05c408325adddc1c5ed6cc1cf