### PR TITLE
Style discography section with album links

### DIFF
--- a/about.html
+++ b/about.html
@@ -139,8 +139,21 @@
       </section>
       <section>
         <h3><strong>Selected Discography (as B_S_)</strong></h3>
-        <p>Better Days Ahead · Slow Down · SDEP · SS-LW · NDMA2 · No More Noise Today</p>
-        <p class="description">Industrial/noise: long-form collages, tape hiss, circuit-bent and digital signal chains.</p>
+        <ul class="discography-list" aria-label="Selected B_S_ releases">
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/better-days-ahead" target="_blank" rel="noopener">Better Days Ahead</a></li>
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/slow-down" target="_blank" rel="noopener">Slow Down</a></li>
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/sdep" target="_blank" rel="noopener">SDEP</a></li>
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/ss-lw" target="_blank" rel="noopener">SS-LW</a></li>
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/ndma2" target="_blank" rel="noopener">NDMA2</a></li>
+          <li><a class="album-link" href="https://bbss.bandcamp.com/album/no-more-noise-today" target="_blank" rel="noopener">No More Noise Today</a></li>
+        </ul>
+        <div class="discography-tags" aria-label="Noise practice tags">
+          <span class="tag">Industrial/Noise</span>
+          <span class="tag">Long-form collages</span>
+          <span class="tag">Tape hiss</span>
+          <span class="tag">Circuit-bent</span>
+          <span class="tag">Digital signal chains</span>
+        </div>
       </section>
       <section>
         <h3><strong>Technical Skills</strong></h3>

--- a/css/style.css
+++ b/css/style.css
@@ -518,3 +518,64 @@ textarea{
 }
 
 textarea:focus{background:#f4f4f4; height:250px;}
+
+/*
+**************************
+DISCOGRAPHY
+**************************
+*/
+
+.discography-list,
+.discography-tags{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  justify-content:center;
+  margin:12px 0 0;
+  padding:0;
+}
+
+.discography-list{
+  list-style:none;
+}
+
+.discography-list li{
+  list-style:none;
+}
+
+.discography-tags{
+  margin-top:16px;
+}
+
+.album-link{
+  display:inline-block;
+  padding:8px 16px;
+  border-radius:999px;
+  background:#111;
+  color:#ffffff;
+  font-weight:600;
+  letter-spacing:0.05em;
+  text-transform:uppercase;
+  font-size:12px;
+  border-bottom:none;
+}
+
+.album-link:hover,
+.album-link:focus{
+  background:#e32c14;
+  color:#ffffff;
+}
+
+.tag{
+  display:inline-block;
+  padding:6px 12px;
+  border-radius:999px;
+  background:#f8f7f7;
+  border:1px solid #dedede;
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:0.03em;
+  text-transform:uppercase;
+  color:#444444;
+  white-space:nowrap;
+}


### PR DESCRIPTION
## Summary
- convert the discography text into external Bandcamp links with centered practice tags
- add pill-style treatments for album links and shared tag styling to align the section

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cc7f1188488325a9e6b3144a2fdf0f