### PR TITLE
Fix fabrication systems method link

### DIFF
--- a/research/index.md
+++ b/research/index.md
@@ -14,7 +14,7 @@ This notebook publishes the scaffolds behind the sampler—Privacy & Ethics, ass
 ## Pages
 - [Privacy & Ethics](/research/privacy-ethics/)
 - [MN42 — Latency Characterization Lab](/research/mn42-latency-lab/)
-- [Fabrication Systems and Methods](/research/Fabrication_System_Met)
+- [Fabrication Systems and Methods](/research/Fabrication_Systems_Met)
 - [Documentation/Ethical Considers](/research/Documentation_Ethics_Me)
 - [Generative AV/Performance Stuff](/research/Generative_AV_Performan)
 - [Instruments/DSP/Control](Instruments_DSP_Control)


### PR DESCRIPTION
## Summary
- correct the Fabrication Systems and Methods link on the research index so it points to the existing page

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce1e157efc83258c7de52485fc93c2