### PR TITLE
Fix YAML wrapping in cds data

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -217,8 +217,7 @@ cards:
     methods:
       - Layered-noise SDF → isosurface (like marching cubes)
       - Relax / quad-remesh and edit for printable topology
-      - Slice with oriented supports; PETG profile noted, PLA/ABS profiles incoming; alt-texted 
-      documentation
+      - Slice with oriented supports; PETG profile noted, PLA/ABS profiles incoming; alt-texted documentation
     outcomes:
       - genF1: physical PETG print (39.5 h), photographed and documented
       - genF2–genF3: print-ready meshes with parameter notes and topology comparisons


### PR DESCRIPTION
## Summary
- fix the genFab methods entry so the YAML list stays on a single line
- unblock the GitHub Pages build that was choking on the malformed data file

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d0575de28c8325b75c3cd3d95c4e58