### PR TITLE
Fix extra print page in CDS sampler

### DIFF
--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -129,7 +129,9 @@
 
   .cds-card {
     break-inside: avoid;
-    break-after: page;
+    page-break-inside: avoid;
+    break-after: auto;
+    page-break-after: auto;
     box-shadow: none;
     border: 1px solid #cbd5e1;
     background: #fff;
@@ -137,8 +139,14 @@
     margin: 0;
   }
 
-  .cds-card:last-of-type {
-    break-after: auto;
+  .cds-card:not(:last-of-type) {
+    break-after: page;
+    page-break-after: always;
+  }
+
+  .sampler-meta {
+    break-before: avoid;
+    page-break-before: auto;
   }
 
   .cds-card figure {


### PR DESCRIPTION
## Summary
- tighten the Critical Digital Studies sampler print CSS so only intermediate cards force a new page
- let the sampler footer ride with the last card to remove the blank ninth sheet when printing

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d18ef1ae24832586fa5f495f05293c