### PR TITLE
Fix extra blank page in sampler print layout

### DIFF
--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -136,12 +136,17 @@
     border: 1px solid #cbd5e1;
     background: #fff;
     padding: 1rem 1.2rem;
-    margin: 0;
+    margin: 0 0 0.5rem;
   }
 
-  .cds-card:not(:last-of-type) {
-    break-after: page;
-    page-break-after: always;
+  .cds-card + .cds-card {
+    break-before: page;
+    page-break-before: always;
+    margin-top: 0;
+  }
+
+  .cds-card:last-of-type {
+    margin-bottom: 0;
   }
 
   .sampler-meta {


### PR DESCRIPTION
## Summary
- adjust the sampler print stylesheet so cards trigger page breaks before each new card instead of forcing breaks after
- trim print margins on the cards so the final card no longer leaves a trailing blank sheet

## Testing
- python tools/lint_sampler.py

------
https://chatgpt.com/codex/tasks/task_e_68d19247d030832589ad59503f1dda04