### PR TITLE
Tighten print layout for final sampler card

### DIFF
--- a/_data/cds.yml
+++ b/_data/cds.yml
@@ -208,6 +208,7 @@ cards:
     title: "Generative Fabrication Techniques"
     img_src: /assets/images/cds/genF1.webp
     img_alt: "genF1: PETG print of a ribboned isosurface with cellular cavities (three-quarter view)"
+    print_compact: true
     abstract: >-
       Code→form pipeline exploring SDF fields, isosurface extraction, and remeshing.
       <strong>genF1</strong> anchors the series as a physical proof: a PETG print that ran

--- a/_includes/cds-card.html
+++ b/_includes/cds-card.html
@@ -1,4 +1,8 @@
-<article id="{{ include.id }}" class="card cds-card" role="region" aria-labelledby="{{ include.id }}-title">
+{% assign card_classes = "card cds-card" %}
+{% if include.print_compact %}
+  {% assign card_classes = card_classes | append: " cds-card--print-compact" %}
+{% endif %}
+<article id="{{ include.id }}" class="{{ card_classes }}" role="region" aria-labelledby="{{ include.id }}-title">
   <div class="card-main">
     {% if include.aligns and include.aligns.size > 0 %}
     <div class="ribbon" aria-label="Alignment tags">

--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -147,6 +147,8 @@
 
   .cds-card:last-of-type {
     margin-bottom: 0;
+    break-before: auto;
+    page-break-before: auto;
   }
 
   .sampler-meta {
@@ -163,6 +165,26 @@
     width: 100%;
     max-height: 3.3in;
     object-fit: cover;
+  }
+
+  .cds-card--print-compact {
+    padding: 0.85rem 1rem;
+  }
+
+  .cds-card--print-compact figure {
+    margin: 0 0 0.35rem;
+  }
+
+  .cds-card--print-compact figure img {
+    max-height: 2.8in;
+  }
+
+  .cds-card--print-compact ul {
+    margin: 0 0 0.35rem;
+  }
+
+  .cds-card--print-compact li {
+    margin-bottom: 0.1rem;
   }
 
   .cds-card .ribbon {

--- a/critical-digital-studies-sampler/index.md
+++ b/critical-digital-studies-sampler/index.md
@@ -40,7 +40,7 @@ updated: "2025-09-14"
 
     <div id="sampler-content" class="sampler-grid">
     {% for c in site.data.cds.cards %}
-    {% include cds-card.html id=c.id title=c.title img_src=c.img_src img_alt=c.img_alt figcaption=c.figcaption abstract=c.abstract aligns=c.aligns methods=c.methods outcomes=c.outcomes teach=c.teach links=c.links %}
+    {% include cds-card.html id=c.id title=c.title img_src=c.img_src img_alt=c.img_alt figcaption=c.figcaption abstract=c.abstract aligns=c.aligns methods=c.methods outcomes=c.outcomes teach=c.teach links=c.links print_compact=c.print_compact %}
     {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow sampler cards to opt into a compact print class so tall entries can shrink when exported
- mark the Generative Fabrication Techniques card as compact and tighten its spacing and figure height for print
- avoid forcing a page break before the final card to remove the extra blank sheet in the PDF export

## Testing
- not run (project does not provide automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d19461e7208325b546ec0d17840a9b