### PR TITLE
Trim print spacing for CDS sampler to stay on eight pages

### DIFF
--- a/assets/css/print-cds.css
+++ b/assets/css/print-cds.css
@@ -44,18 +44,18 @@
   }
 
   body {
-    font-size: 10.25pt;
-    line-height: 1.28;
+    font-size: 10pt;
+    line-height: 1.25;
     background: #fff;
     color: #0f172a;
   }
 
   p {
-    margin: 0 0 0.35rem;
+    margin: 0 0 0.32rem;
   }
 
   ul {
-    margin: 0 0 0.45rem;
+    margin: 0 0 0.42rem;
     padding-left: 0.95rem;
   }
 
@@ -135,7 +135,7 @@
     box-shadow: none;
     border: 1px solid #cbd5e1;
     background: #fff;
-    padding: 1rem 1.2rem;
+    padding: 0.95rem 1.1rem;
     margin: 0 0 0.5rem;
   }
 
@@ -225,14 +225,14 @@
   .cds-card h2 {
     font-size: 1.25rem;
     line-height: 1.15;
-    margin-bottom: 0.45rem;
+    margin-bottom: 0.4rem;
   }
 
   .cds-card h3 {
     font-size: 1.05rem;
     letter-spacing: 0.01em;
-    margin-top: 0.5rem;
-    margin-bottom: 0.3rem;
+    margin-top: 0.45rem;
+    margin-bottom: 0.28rem;
   }
 
   .cds-card h3 + ul {


### PR DESCRIPTION
## Summary
- slightly reduce print typography sizing and spacing for the CDS sampler
- trim card padding and heading spacing so the final project stays within the eighth page

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d197247fa88325ae5b74a2574c5e63