### PR TITLE
Modernize portfolio layout responsiveness

### DIFF
--- a/css/style-responsive.css
+++ b/css/style-responsive.css
@@ -1,328 +1,69 @@
-@media all and (max-width: 1330px) and (min-width: 1180px) {
+/* Responsive adjustments for the refreshed fluid layout */
 
-  header.boxed .header-margin{
-    width:1000px;
+@media (max-width: 1200px) {
+  .content{
+    padding:0 clamp(1.25rem, 4vw, 2.5rem);
   }
-
-  .content .text-intro{
-    width:1000px;
-  }
-
-  .footer-margin{
-    width:1000px;
-  }
-
-  .content .text-intro h1, .content .text-intro p{
-    width:60%;
-  }
-
-  #full{
-    width:1000px;
-  }
-
-  .prev-next{
-    max-width:1000px;
-  }
-
-
-  /*
-  **************************
-  Portfolio Grid
-  **************************
-  */
-
-  #portfolio-sidebar{
-
-    width: 710px !important;
-    padding-right: 320px;
-  }
-
-  .portfolio-grid{
-
-    width:1030px;
-
-  }
-
-  .grid-hover, li.grid-item, li.grid-item img{
-    width:312px;
-  }
-
-
 }
 
-
-@media all and (max-width: 1179px) and (min-width: 1024px) {
-
-
-  header.boxed .header-margin{
-    width:800px;
+@media (max-width: 960px) {
+  .content{
+    margin:clamp(2rem, 8vw, 4rem) auto clamp(2.5rem, 10vw, 5rem);
   }
 
   .content .text-intro{
-    width:800px;
+    margin:clamp(2.5rem, 8vw, 4.5rem) auto clamp(1.5rem, 6vw, 3.5rem);
   }
-
-  .footer-margin{
-    width:800px;
-  }
-
-  .content .text-intro h1, .content .text-intro p{
-    width:60%;
-  }
-
-  #full{
-    width:800px;
-  }
-
-  .prev-next{
-    max-width:800px;
-  }
-
-
-  /*
-  **************************
-  Portfolio Grid
-  **************************
-  */
-
-  #portfolio-sidebar{
-
-    width: 580px !important;
-    padding-right: 250px;
-  }
-
-  .portfolio-grid{
-
-    width:830px;
-
-  }
-
-  .grid-hover, li.grid-item, li.grid-item img{
-    width:246px;
-  }
-
 }
 
-
-@media all and (max-width: 1023px) and (min-width: 769px) {
-
-
-  header.boxed .header-margin{
-    width:600px;
-  }
-
+@media (max-width: 720px) {
   .content .text-intro{
-    width:600px;
+    text-align:center;
   }
 
-  .footer-margin{
-    width:600px;
-  }
-
-  .content .text-intro h1, .content .text-intro p{
-    width:100%;
-  }
-
-  #full{
-    width:600px;
-  }
-
-  .prev-next{
-    max-width:600px;
-  }
-
-
-
-
-  /*
-  **************************
-  Portfolio Grid
-  **************************
-  */
-
-  #portfolio-sidebar{
-
-    width:630px !important;
-    padding-right: 0;
+  .content .text-intro p{
+    text-align:center;
   }
 
   .portfolio-grid{
-    width:630px;
+    grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
   }
-
-  .grid-hover, li.grid-item, li.grid-item img{
-    width:282px;
-  }
-
 }
 
-
-
-@media all and (max-width: 768px) and (min-width: 481px) {
-
-
-  header.boxed .header-margin{
-    width:400px;
-  }
-
-  .content .text-intro{
-    width:400px;
-  }
-
-  .footer-margin{
-    width:400px;
-  }
-
-  .content .text-intro h1, .content .text-intro p{
-    width:100% !important;
-  }
-
-  #full{
-    width:100%;
-    display:block !important;
-  }
-
-  .menu-index{
-    display:block !important;
-  }
-
-  .prev-next{
-    max-width:400px;
-  }
-
-
-  .one-column, .two-column{
-    width:100%;
-  }
-
-  .contact-one, .contact-two, .contact-three{
-    width:100%;
-  }
-
-  textarea{
-    height:250px;
-  }
-
-  input.button-submit{
-    margin-bottom:100px;
-  }
-
-  .logo, .menu-index{
-    display:block;
-  }
-
-  header.boxed{
-    display:none !important;
-  }
-
-  #footer-left{text-align:center;}
-
-  /*
-  **************************
-  Portfolio Grid
-  **************************
-  */
-
-  #portfolio-sidebar{
-
-    width:430px !important;
-    padding-right: 0;
+@media (max-width: 540px) {
+  .content{
+    padding:0 clamp(1rem, 6vw, 1.75rem);
   }
 
   .portfolio-grid{
-    width:430px;
+    grid-template-columns:1fr;
+    gap:clamp(1.25rem, 6vw, 2rem);
   }
 
-  .grid-hover, li.grid-item, li.grid-item img{
-    width:400px;
+  li.grid-item{
+    border-radius:20px;
   }
-
 }
 
-
-@media all and (max-width: 480px) and (min-width: 320px) {
-
-
-  header.boxed .header-margin{
-    width:280px;
+@media (max-width: 420px) {
+  .grid-hover h1,
+  .grid-hover h2{
+    font-size:clamp(1.3rem, 1.1rem + 1vw, 1.6rem);
   }
 
-  .content .text-intro{
-    width:280px;
+  .grid-hover p{
+    font-size:clamp(0.95rem, 0.9rem + 0.4vw, 1.05rem);
+  }
+}
+
+@media (hover: none) {
+  .grid-hover{
+    opacity:1;
+    transform:none;
+    background:linear-gradient(180deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.78) 100%);
   }
 
-  .footer-margin{
-    width:280px;
+  li.grid-item img{
+    transform:none !important;
   }
-
-  .footer-margin .copyright{line-height:40px;}
-
-  .content .text-intro h1, .content .text-intro p{
-    width:100% !important;
-  }
-
-  #full{
-    width:280px;
-    display:block !important;
-  }
-
-  .menu-index{
-    display:block !important;
-  }
-
-  .prev-next{
-    max-width:280px;
-  }
-
-  .one-column, .two-column{
-    width:100%;
-  }
-
-  .contact-one, .contact-two, .contact-three{
-    width:100%;
-  }
-
-  textarea{
-    height:250px;
-  }
-
-  input, textarea{
-    padding:0;
-  }
-
-  input.button-submit{
-    margin-bottom:100px;
-  }
-
-  header.boxed{
-    display:none !important;
-  }
-
-  #footer-left{text-align:center;}
-
-  .content .text-intro h1{
-    font-size:33px;
-    line-height:50px;
-  }
-
-  /*
-  **************************
-  Portfolio Grid
-  **************************
-  */
-
-  #portfolio-sidebar{
-
-    width:310px !important;
-    padding-right: 0;
-  }
-
-  .portfolio-grid{
-    width:310px;
-  }
-
-  .grid-hover, li.grid-item, li.grid-item img{
-    width:280px;
-  }
-
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,18 @@
 
+*, *::before, *::after{
+  box-sizing:border-box;
+}
+
 body{
   font-family: 'Raleway', sans-serif;
   font-size:14px;
   font-weight: 400;
+  line-height:1.6;
   overflow-y:scroll;
   -webkit-font-smoothing: antialiased;
+  color:#0f172a;
+  background:linear-gradient(135deg, #f8fafc 0%, #eef2ff 45%, #ffffff 100%);
+  margin:0;
 }
 
 ::selection {
@@ -225,44 +233,52 @@ CONTENT
 
 .content{
   position:relative;
-  width:1140px;
-  margin:50px auto;
+  width:min(100%, 94vw);
+  max-width:1280px;
+  margin:clamp(2.5rem, 7vw, 5rem) auto clamp(3rem, 9vw, 6rem);
+  padding:0 clamp(1.5rem, 4vw, 3rem);
 }
 
 
 .content .text-intro{
-  align-content: center;
-  width: 1140px;
-  margin-top: 100px;
-  margin: 150px auto 0;
+  width:min(100%, 68ch);
+  margin:clamp(3rem, 9vw, 6rem) auto clamp(2rem, 6vw, 4rem);
+  display:grid;
+  gap:clamp(1rem, 3vw, 1.75rem);
+  text-align:center;
 }
 
 .content .text-intro h1{
-  font-size:45px;
-  width:65%;
+  font-size:clamp(2.4rem, 1.8rem + 2vw, 3.6rem);
+  width:100%;
   text-transform:uppercase;
-  color:#000000;
+  color:#0b1431;
   font-weight:800;
-  line-height:65px;
+  line-height:1.12;
+  letter-spacing:0.08em;
+  margin:0;
 }
 
 .content .text-intro h2{
-  font-size:40px;
-  width:50%;
+  font-size:clamp(2rem, 1.6rem + 1.5vw, 3rem);
+  width:100%;
   text-transform:uppercase;
-  color:#000000;
+  color:#0b1431;
   font-weight:800;
-  line-height:65px;
+  line-height:1.12;
+  letter-spacing:0.08em;
+  margin:0;
 }
 
 .content .text-intro p{
-  font-size:13px;
-  color:#8d8d8d;
-  margin-top:15px;
-  font-weight:275;
-  line-height:20px;
-  letter-spacing:1px;
-  width:50%;
+  font-size:clamp(1rem, 0.92rem + 0.35vw, 1.12rem);
+  color:#4b5563;
+  margin:0 auto;
+  font-weight:400;
+  line-height:1.7;
+  letter-spacing:0.03em;
+  width:100%;
+  max-width:60ch;
 }
 
         .typed-cursor{
@@ -307,11 +323,13 @@ PORTFOLIO GRID
 */
 
 .portfolio-grid{
-  width:1170px;
-  position:flex;
-  flex-wrap: wrap-reverse;
-  margin: 30px auto;
-  overflow:hidden;
+  width:100%;
+  margin:clamp(1.5rem, 4vw, 3rem) auto 0;
+  padding:0;
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap:clamp(1.5rem, 3vw, 2.75rem);
+  list-style:none;
 }
 
 #portfolio-sidebar{
@@ -320,56 +338,94 @@ PORTFOLIO GRID
 }
 
 li.grid-item{
-  width:360px;
   position:relative;
-  float: inherit;
-  padding:15px;
+  display:flex;
+  align-items:stretch;
+  justify-content:center;
+  overflow:hidden;
+  border-radius:clamp(18px, 3vw, 28px);
+  box-shadow:0 35px 70px -45px rgba(15, 23, 42, 0.5);
+  min-height:260px;
+  background:#0f172a;
+  transition:transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+li.grid-item:hover,
+li.grid-item:focus-within{
+  transform:translateY(-6px);
+  box-shadow:0 45px 90px -50px rgba(15, 23, 42, 0.6);
+}
+
+li.grid-item > a{
+  position:absolute;
+  inset:0;
+  display:flex;
+  align-items:stretch;
+  justify-content:center;
+  border-bottom:0;
+  color:inherit;
+  text-decoration:none;
+  cursor:pointer;
 }
 
 .grid-hover{
-  position: absolute;
-  width:360px;
-  height: 100%;
-  top:0;
-  background: white;
-  z-index: 2;
-  opacity: 0;
-  -webkit-transition: all 0.2s ease-in;
-	-moz-transition: all 0.2s ease-in;
-	-ms-transition: all 0.2s ease-in;
-	-o-transition: all 0.2s ease-in;
-	transition: all 0.2s ease-in;
-}
-
-.grid-hover:hover{
-  opacity: 0.9;
-}
-
-.grid-hover h1{
-  font-size:23px;
-  bottom:80px;
-  left:40px;
   position:absolute;
+  inset:0;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:clamp(1.5rem, 4vw, 2.75rem);
+  background:linear-gradient(180deg, rgba(15, 23, 42, 0.1) 0%, rgba(15, 23, 42, 0.68) 75%, rgba(15, 23, 42, 0.85) 100%);
+  color:#f8fafc;
+  z-index:2;
+  opacity:0;
+  transform:translateY(12px);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+  backdrop-filter:blur(6px);
+}
+
+li.grid-item:hover .grid-hover,
+li.grid-item:focus-within .grid-hover{
+  opacity:1;
+  transform:translateY(0);
+}
+
+.grid-hover h1,
+.grid-hover h2{
+  font-size:clamp(1.4rem, 1.2rem + 0.6vw, 1.9rem);
   text-transform:uppercase;
-  color:#000000;
-  letter-spacing:1px;
-  font-weight:900;
-  line-height:50px;
+  color:#f1f5f9;
+  letter-spacing:0.1em;
+  font-weight:800;
+  line-height:1.3;
+  margin:0 0 0.75rem 0;
 }
 
 .grid-hover p{
-  font-size:13px;
-  bottom:40px;
-  left:40px;
-  position:absolute;
-  color:#686868;
-  letter-spacing:1px;
-  font-weight:400;
-  line-height:50px;
+  font-size:clamp(0.95rem, 0.88rem + 0.3vw, 1.05rem);
+  color:#e2e8f0;
+  letter-spacing:0.05em;
+  font-weight:500;
+  line-height:1.6;
+  margin:0;
+  max-width:38ch;
 }
 
 li.grid-item img{
-  width:360px;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+  transition:transform 0.45s ease, filter 0.45s ease;
+  filter:saturate(0.95);
+}
+
+li.grid-item:hover img,
+li.grid-item:focus-within img{
+  transform:scale(1.05);
+  filter:saturate(1.05);
 }
 
 li.grid-item iframe{
@@ -389,49 +445,57 @@ FOOTER
 
 
 footer{
-  background: #f1f1f1;
+  background:rgba(241, 245, 249, 0.88);
   width:100%;
-  margin-top:100px;
-  height:300px;
-  overflow:hidden;
+  margin-top:clamp(4rem, 10vw, 7rem);
+  padding:clamp(2rem, 6vw, 4rem) 0;
   position:relative;
   z-index:10;
+  backdrop-filter:blur(6px);
 }
 
 .footer-margin{
-  width:1140px;
-  margin: 30px auto;
-  line-height: 100px;
+  width:min(100%, 94vw);
+  max-width:1280px;
+  margin:0 auto;
+  line-height:1.7;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:clamp(0.75rem, 3vw, 1.5rem);
+  color:#475569;
 }
 
-#footer-left{text-align:left;}
+#footer-left{text-align:center;}
 
 .footer-margin .copyright{
-  color: #686868;
-  letter-spacing: 1px;
-  font-size: 12px;
-  width: 100%;
+  color:#475569;
+  letter-spacing:0.08em;
+  font-size:0.8rem;
+  width:100%;
   text-align:center;
-  float: left;
 }
 
 .footer-margin .social-footer{
-  color: #686868;
-  letter-spacing: 1px;
-  font-size: 13px;
-  width: 100%;
+  color:#475569;
+  letter-spacing:0.05em;
+  font-size:0.85rem;
+  width:100%;
   text-align:center;
-  float: left;
+  display:flex;
+  justify-content:center;
+  gap:clamp(0.75rem, 3vw, 1.75rem);
 }
 
 .footer-margin .social-footer a{
-  font-size:15px;
-  color:black;
-  padding: 20px;
+  font-size:1.1rem;
+  color:#0f172a;
+  padding:0.75rem;
+  border-bottom:0;
 }
 
 .footer-margin .social-footer a:hover{
-  color:#c3c3c3;
+  color:#1d4ed8;
 }
 
 

--- a/js/script.js
+++ b/js/script.js
@@ -113,6 +113,18 @@ Masonry Check Script
 function Masonry() {
        var $container = $('.portfolio-grid');
 
+       if(!$container.length){
+         return;
+       }
+
+       var containerEl = $container.get(0);
+       if(containerEl){
+         var displayMode = window.getComputedStyle(containerEl).display;
+         if(displayMode && displayMode.indexOf('grid') === 0){
+           return;
+         }
+       }
+
        $container.imagesLoaded( function(){
          $container.masonry({
            itemSelector : 'li'


### PR DESCRIPTION
## Summary
- rework the landing page containers and typography spacing so the main portfolio scales fluidly across viewports
- rebuild the portfolio grid and hover overlays with a CSS grid system plus updated mobile-specific rules
- refresh the footer styling and guard the Masonry helper so it defers to the new CSS grid layout

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e192d4ac832589c148aeee6002cf