### PR TITLE
Expand portfolio page images to full viewport width

### DIFF
--- a/2d/banners.html
+++ b/2d/banners.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Banners-</h1>
 	          <div class="one-column">
 	            <p>Some flags too,</p>

--- a/2d/divine.html
+++ b/2d/divine.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Jacskass-</h1>
 	          <div class="one-column">
 	            <p>Darwings, collage, paint</p>

--- a/2d/hate.html
+++ b/2d/hate.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-The truth is, I hate to tell you-</h1>
 	          <div class="one-column">
 	            <p>Durational drawing series</p>

--- a/2d/stalker.html
+++ b/2d/stalker.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Nightstalker Re-Runs on Channel 4-</h1>
 	          <div class="one-column">
 	            <p>Photographs</p>

--- a/2d/untitled.html
+++ b/2d/untitled.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Untitled (an act of war)-</h1>
 	          <div class="one-column">
 	            <p>The names of all of the children from Pakistan and Yemen killed by US drone strikes as of June 16, 2011</p>

--- a/3d/bath.html
+++ b/3d/bath.html
@@ -54,7 +54,7 @@
   </header>
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Digital Bath/Engram-</h1>
 	          <div class="one-column">
 	            <p>Sculpture, Projection, Installation</p>

--- a/3d/call.html
+++ b/3d/call.html
@@ -54,7 +54,7 @@
   </header>
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Delay hasn't cost me a thing-</h1>
 	          <div class="one-column">
 	            <p>Sculpture</p>

--- a/3d/choke.html
+++ b/3d/choke.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-I hope you choke-</h1>
 	          <div class="one-column">
 	            <p>Ceiling fan from my childhood homee, steel cable, Action</p>

--- a/3d/con.html
+++ b/3d/con.html
@@ -54,7 +54,7 @@
   </header>
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Construct/Obstruct-</h1>
 	          <div class="one-column">
 	            <p>Sculpture, Projection, Installation</p>

--- a/3d/fly.html
+++ b/3d/fly.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Are you ready to fly? (It looks like we have our work cut out for us)-</h1>
 	          <div class="one-column">
 	            <p>Installation</p>

--- a/3d/genfab.html
+++ b/3d/genfab.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Generative Fabrication Techniques-</h1>
                   <div class="one-column">
                     <p>Code-driven fabrication studies built with Structure Synth, custom Processing

--- a/3d/lie.html
+++ b/3d/lie.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>I'd never lie to you</h1>
 	          <div class="one-column">
 	            <p>Action</p>

--- a/3d/party.html
+++ b/3d/party.html
@@ -54,7 +54,7 @@
   </header>
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-I can't tell where to begin-</h1>
 	          <div class="one-column">
 	            <p>Action</p>

--- a/3d/redstairs.html
+++ b/3d/redstairs.html
@@ -54,7 +54,7 @@
   </header>
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-Red Stairs/Somebody please save us-</h1>
 	          <div class="one-column">
 	            <p>Action</p>

--- a/3d/truth.html
+++ b/3d/truth.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-We hold these truths-</h1>
 	          <div class="one-column">
 	            <p>Installation</p>

--- a/3d/war.html
+++ b/3d/war.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>They're preparing for war</h1>
 	          <div class="one-column">
 	            <p>Installation</p>

--- a/3d/warning.html
+++ b/3d/warning.html
@@ -55,7 +55,7 @@
 
   <!--Content-->
   <div class="content" id="ajax-content">
-        <div class="text-intro">
+        <div class="text-intro text-intro--full-bleed">
           <h1>-I'd never lie to you-</h1>
 	          <div class="one-column">
 	            <p>Installation</p>

--- a/css/style.css
+++ b/css/style.css
@@ -283,6 +283,32 @@ CONTENT
 
 /*
 **************************
+FULL BLEED MEDIA GALLERIES
+**************************
+*/
+.text-intro--full-bleed{
+  width:100%;
+  max-width:none;
+  justify-items:center;
+  text-align:center;
+}
+
+.text-intro--full-bleed > :not(img){
+  width:100%;
+  max-width:min(100%, 68ch);
+  margin-inline:auto;
+}
+
+.text-intro--full-bleed img{
+  display:block;
+  width:min(100%, 100vw);
+  max-width:none;
+  margin-left:calc(50% - 50vw);
+  margin-right:calc(50% - 50vw);
+}
+
+/*
+**************************
 ABOUT PAGE LAYOUT BOOST
 **************************
 */


### PR DESCRIPTION
## Summary
- add a full-bleed gallery helper that lets project imagery reach the viewport edges
- attach the helper class to each legacy 2D and 3D portfolio page so their documentation images expand

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d31e0f175083259559828218e854ee