### PR TITLE
Improve mobile menu and enlarge detail media

### DIFF
--- a/css/style-responsive.css
+++ b/css/style-responsive.css
@@ -28,6 +28,34 @@
   .portfolio-grid{
     grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
   }
+
+  .opacity-nav{
+    padding:clamp(3rem, 12vh, 6rem) clamp(1.5rem, 6vw, 2.5rem);
+    overflow:auto;
+  }
+
+  ul.menu-fullscreen{
+    position:static;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    gap:clamp(1.5rem, 6vh, 2.75rem);
+    width:100%;
+    height:auto;
+    margin:auto;
+  }
+
+  ul.menu-fullscreen li{
+    font-size:clamp(1.6rem, 1.3rem + 2vw, 2.4rem);
+    line-height:1.35;
+  }
+
+  ul.menu-fullscreen li > a{
+    display:block;
+    width:100%;
+    padding:clamp(0.85rem, 3vh, 1.4rem);
+  }
 }
 
 @media (max-width: 540px) {

--- a/css/style.css
+++ b/css/style.css
@@ -299,12 +299,29 @@ FULL BLEED MEDIA GALLERIES
   margin-inline:auto;
 }
 
-.text-intro--full-bleed img{
+.text-intro--full-bleed img,
+.text-intro--full-bleed iframe,
+.text-intro--full-bleed video{
   display:block;
   width:min(100%, 100vw);
   max-width:none;
   margin-left:calc(50% - 50vw);
   margin-right:calc(50% - 50vw);
+}
+
+@media (min-width: 960px){
+  .text-intro--full-bleed img,
+  .text-intro--full-bleed iframe,
+  .text-intro--full-bleed video{
+    width:min(100vw, 1800px);
+    margin-left:calc(50% - min(50vw, 900px));
+    margin-right:calc(50% - min(50vw, 900px));
+  }
+
+  .text-intro--full-bleed iframe,
+  .text-intro--full-bleed video{
+    min-height:clamp(520px, 60vh, 1040px);
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary
- restyle the fullscreen navigation overlay so that it scales into a centered, scrollable column on mobile screens
- allow detail page media to span up to 1800px wide on large viewports, covering images, videos, and iframes together with taller minimum heights for embeds

## Testing
- not run (static assets change only)


------
https://chatgpt.com/codex/tasks/task_e_68d36b1823c48325938cd0757512be80