### PR TITLE
Refactor landing into accessible three-pillar site

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Not found · Ben Severns</title>
+  <meta name="description" content="The page you were looking for is archived or renamed. Head back to the latest from Ben Severns.">
+  <link rel="canonical" href="https://bseverns.github.io/404.html">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Not found · Ben Severns">
+  <meta property="og:description" content="The page you were looking for is archived or renamed. Head back to the latest from Ben Severns.">
+  <meta property="og:url" content="https://bseverns.github.io/404.html">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Not found · Ben Severns">
+  <meta name="twitter:description" content="The page you were looking for is archived or renamed. Head back to the latest from Ben Severns.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
+      </div>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main id="main" class="site-main" tabindex="-1">
+    <div class="container page-intro">
+      <h1>Page not found</h1>
+      <p>The page you requested has moved, been archived, or never existed. Try these fresh entry points:</p>
+      <ul>
+        <li><a href="/">Start at the homepage</a></li>
+        <li><a href="/art.html">Studio projects</a></li>
+        <li><a href="/courses.html">Teaching projects</a></li>
+      </ul>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,59 @@
 # bseverns.github.io
 
-Welcome to the stitched-together portfolio of Ben Severns. This repo runs on vanilla Jekyll with collections for studio projects (`_projects/`) and teaching bits (`_teaching/`). Everything's plain text so you can fork, remix, and learn.
+This repo now runs like a stripped-down landing pad for Ben Severns: three pillars (Tools / Scenes / Learning), a press kit with living copy, and a tiny JS layer that only does conditional image checks. Think studio notebook meets teaching guide—every file is here to explain itself.
+
+## Stack snapshot
+- **HTML**: Hand-authored pages at the project root (`index.html`, `art.html`, `courses.html`, `press-kit.html`, `contact.html`, `404.html`). No templates, no includes—what you see is what ships.
+- **CSS**: One file, [`/css/site.css`](css/site.css). It handles layout, color systems (light/dark), placeholders, and focus states.
+- **JS**: [`/js/site.js`](js/site.js) for conditional image rendering, asset status badges, and footer year updates. [`/js/archive-banner.js`](js/archive-banner.js) exists for legacy pages only.
+- **No images baked in**: JavaScript does a `HEAD` request before inserting any `<img>`. Missing files borrow an in-repo fallback photo before dropping to an accessible placeholder block.
+
+## Local dev (pick your flavor)
+1. **Quick static preview** (no build step):
+   ```bash
+   npx serve .
+   ```
+   or any static web server (`python -m http.server`, `ruby -run -ehttpd . -p 4000`, etc.).
+2. **Jekyll folks**: the repo still contains old `_projects/` content. If you need them, run `bundle exec jekyll serve` and everything—including the new flat files—will compile. The new landing doesn’t rely on Jekyll though.
+
+## Content map
+| File | Intent |
+| --- | --- |
+| `index.html` | Hero statement, three-pillar cards, What’s New list, archive note. Edit the list in-place (there’s a reminder comment). |
+| `art.html` | Studio starter cards. Swap copy + links as projects solidify. |
+| `courses.html` | Teaching starter cards with comment-callouts for pending links. |
+| `press-kit.html` | Contains the 100-word and 300-word bios, quick facts, image drop points. JS turns asset paths into ✅ links if files exist. |
+| `contact.html` | Email + social routes. Points media back to the press kit. |
+| `404.html` | Friendly reroute to the main sections. |
+| `robots.txt` & `sitemap.xml` | Pre-baked for search engines; update `lastmod` dates when you ship meaningful changes. |
+
+## Working with images (without shipping new ones)
+- Drop files at the listed paths (`/img/press/headshot.jpg`, `/img/social/og-banner.jpg`, etc.) and refresh—JS will surface them.
+- If a path stays empty, the placeholder announces itself via `aria-label="… (placeholder)"` so screen readers know what’s happening.
+- Want different art on a card? Update the `data-src` and `data-alt` attributes and the script does the rest.
+
+## Archiving the old site (optional but handy)
+Legacy HTML still lives throughout this repo. To tack on the new archive banner + canonical link automatically:
+```bash
+node tools/attach-archive-banner.js
+```
+The script walks every `.html` file outside the new set and injects:
+- `<script src="/js/archive-banner.js" defer></script>` before `</body>`
+- `<link rel="canonical" href="https://bseverns.github.io/">` in `<head>` if it’s missing
+It’s idempotent—run it as often as you like.
+
+## Editing rituals
+- **What’s New**: keep three bullets live; swap them as projects shift. The inline comment in `index.html` is your reminder.
+- **Cards**: each card has a `data-src` and `data-alt`. Leave them empty rather than pointing at non-existent media.
+- **Press kit copy**: treat it like source-of-truth text. Update bios here first; elsewhere should link back.
+- **Accessibility + SEO**: titles, descriptions, JSON-LD, and Open Graph tags are all hard-coded per page. Keep descriptions under ~160 chars when you edit.
+
+## Testing checklist
+- Load pages in a browser with DevTools open—watch the network tab for `HEAD` requests only (no `GET` on missing images).
+- Tab through everything to confirm focus rings stay visible.
+- Run Lighthouse (desktop) and aim for 95+ across the board. The lightweight stack makes that achievable without extra tuning.
 
 ## License
-
 Content: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
 
----
-Built for documentation and teaching. Critique welcome.
+Built for curiosity, remixing, and the kind of documentation that lets other people build faster.

--- a/art.html
+++ b/art.html
@@ -1,406 +1,104 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
-  <title>B. Severns | Selected Works</title>
-  <meta name="description" content="Web Portfolio of Ben Severns, Minneapolis-based artist/educator ">
-  <meta name="keywords" content="art, Minneapolis, technology, postmodern, kinetic, glitch, photography, sculpture, drawing, art education, installation, protest, fine art, contemporary art, art installation, anti-art, sound art, error art, chance art, SoftSculpture, soft sculpture, techno-art, robot art, kinetic art, punk rock, noise music, newnow">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta name="author" content="B.Severns">
-  <link rel="icon" type="image/png" href="img/icon.png" />
-  <!--Style-->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,300,500,600,700,800,900,100,200"/>
-  <link rel="stylesheet" href="css/reset.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <!--
-  <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
-  <script src="js/tunnelSketch.js"></script>
-  -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Studio projects · Ben Severns</title>
+  <meta name="description" content="Studio projects from Ben Severns: consent-forward installations, instruments, and performance systems.">
+  <link rel="canonical" href="https://bseverns.github.io/art.html">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Studio projects · Ben Severns">
+  <meta property="og:description" content="Studio projects from Ben Severns: consent-forward installations, instruments, and performance systems.">
+  <meta property="og:url" content="https://bseverns.github.io/art.html">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Studio projects · Ben Severns">
+  <meta name="twitter:description" content="Studio projects from Ben Severns: consent-forward installations, instruments, and performance systems.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://bseverns.github.io/"},
+      {"@type":"ListItem","position":2,"name":"Studio","item":"https://bseverns.github.io/art.html"}
+    ]
+  }
+  </script>
 </head>
-
 <body>
-  <!--Preloader-->
-  <div class="preloader" id="preloader">
-    <div class="item">
-      <div class="spinner">
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
       </div>
-    </div>
-  </div>
-
-  <!--nav buttons-->
-  <div class="opacity-nav">
-    <div class="menu-index" id="buttons" style="z-index:99999">
-      <i class="fa  fa-close"></i>
-    </div>
-
-    <ul class="menu-fullscreen">
-      <li><a href="index.html">Home/Portfolio</a></li>
-      <li><a href="/about/">About/CV</a></li>
-      <li><a href="contact.html">Contact</a></li>
-    </ul>
-  </div>
-
-  <!--Header image/menu-->
-  <header id="fullscreen">
-    <img loading="lazy" src="img/front/banner.gif" alt="glitchy rainbow banner">
-    <div class="menu-index" id="button">
-      <i class="fa fa-th"></i>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html" aria-current="page">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
-
-  <!--Content-->
-  <div class="content">
-    <div class="text-intro">
-      <h1>Studio Portfolio</h1>
-      <p>Hover a tile to get the gist. Click through if you want the full noise.</p>
+  <main id="main" class="site-main" tabindex="-1">
+    <div class="container page-intro">
+      <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li aria-current="page">Studio</li>
+        </ol>
+      </nav>
+      <h1>Studio projects</h1>
+      <p>Scenes, installations, and performances that foreground agency, documentation, and reproducibility.</p>
     </div>
-    <ul class="portfolio-grid">
 
-<li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/truth.jpg" alt="We hold these truths artwork thumbnail">
-  <a href="3d/truth.html">
-    <div class="grid-hover">
-      <h1>We hold these truths</h1>
-      <p>Television, Rope, Audio, Installation</p>
+    <div class="container card-grid">
+      <article class="card">
+        <div class="card-visual" data-src="/img/portfolio/flat/ex1.jpg" data-alt="Synth modules and performance setup"></div>
+        <div class="card-body">
+          <h2>MOARkNOBS-42 live rig</h2>
+          <p>Modular instrument rig with latency ledgers and reproducible routing for collaborators.</p>
+          <a class="card-link" href="https://github.com/bseverns/MOARkNOBS-42">Read the build notes</a>
+        </div>
+      </article>
+      <article class="card">
+        <div class="card-visual" data-src="/img/portfolio/3d/truth.jpg" data-alt="Projection-mapped installation still"></div>
+        <div class="card-body">
+          <h2>Consent-forward sensing kiosk</h2>
+          <p>Interactive station that foregrounds opt-in telemetry, hushing surveillance vibes.</p>
+          <!-- TODO: Replace with final project write-up once published. -->
+          <span class="card-link pending" role="text">Project walk-through coming soon</span>
+        </div>
+      </article>
+      <article class="card">
+        <div class="card-visual" data-src="/img/portfolio/3d/save.jpg" data-alt="Immersive light installation still"></div>
+        <div class="card-body">
+          <h2>Room-playing media suite</h2>
+          <p>Audio-responsive environment mapping space as collaborator rather than channel.</p>
+          <!-- TODO: Swap in documentation link once ready. -->
+          <span class="card-link pending" role="text">Documentation in production</span>
+        </div>
+      </article>
     </div>
-  </a>
-</li>
-
-<!--No More Noise Today album - BS-->
-<li class="grid-item" data-jkit="[show:delay=3200; speed=500;animation=fade]">
-  <iframe style="border: 0; width: 250px; height: 400px;" src="https://bandcamp.com/EmbeddedPlayer/album=1691167730/size=large/bgcol=333333/linkcol=e32c14/tracklist=false/transparent=true/" seamless><a
-      href="https://bbss.bandcamp.com/album/no-more-noise-today">No More Noise Today by B_S_</a></iframe>
-</li>
-
-<!--video something -->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/199860540" width=“250” height=“450” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!-- - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe width="250" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/246625996"></iframe>
-</li>
-
-<!--Construct/Obstruct-->
-<li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img loading="lazy" src="3d/full3d/conob.jpeg" alt="Construct//Obstruct artwork thumbnail">
-  <a href="3d/con.html">
-    <div class="grid-hover">
-      <h1>Construct//Obstruct</h1>
-      <p>Wood, Canvas, Java Program, Digital Video, Installation</p>
-    </div>
-  </a>
-</li>
-
-<!--Generative Fabrication Techniques-->
-<li class="grid-item" data-jkit="[show:delay=2600;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/genF1.jpg" alt="Generative Fabrication Techniques PETG print thumbnail">
-  <a href="3d/genfab.html">
-    <div class="grid-hover">
-      <h1>Generative Fabrication Techniques</h1>
-      <p>Code-built isosurfaces, PETG print series, process notes</p>
-    </div>
-  </a>
-</li>
-
-<!--No Sound EP album - BS-->
-<li class="grid-item" data-jkit="[show:delay=3100; speed=500;animation=fade]">
-  <iframe style="border: 0; width: 250px; height: 400px;" src="https://bandcamp.com/EmbeddedPlayer/album=1307010633/size=large/bgcol=ffffff/linkcol=de270f/tracklist=false/transparent=true/" seamless><a
-      href="https://bbss.bandcamp.com/album/no-sound-again-ep">No Sound [again] EP by B_S_</a></iframe>
-</li>
-
-<!--context-->
-<li class="grid-item" data-jkit="[show:delay=3750;speed=500;animation=fade]">
-  <img loading="lazy" src="img/front/context.jpg" alt="CONTEXT sketchbook thumbnail">
-  <a href="https://bseverns.tumblr.com" target="_blank">
-    <div class="grid-hover">
-      <h1>CONTEXT</h1>
-      <p>Sketch, Catalog, Feedback</p>
-    </div>
-  </a>
-</li>
-
-<!--Research hub-->
-<li class="grid-item" data-jkit="[show:delay=3800;speed=500;animation=fade]">
-  <img loading="lazy" src="img/front/research-placeholder.svg" alt="Research portal placeholder graphic">
-  <a href="/research/" target="_blank" rel="noopener">
-    <div class="grid-hover">
-      <h1>Research</h1>
-      <p>Methods, instruments, and receipts.</p>
-    </div>
-  </a>
-</li>
-
-<!--Poetry is what happens when nothing else can-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/118443299" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--Tonal Dissonance-->
-<li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/hook.jpg" alt="Tonal dissonance artwork thumbnail">
-  <a href="3d/redstairs.html">
-    <div class="grid-hover">
-      <h1>Tonal dissonance</h1>
-      <p>Wood, steel, recorded and live audio, amplifiers, audio effects</p>
-    </div>
-  </a>
-</li>
-
-<!--Ghosts [1]-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/176236653" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--Jackass-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/flat/ex1.jpg" alt="Jackass artwork thumbnail">
-  <a href="2d/divine.html">
-    <div class="grid-hover">
-      <h1>Jackass(Experiments in rendering the divine)</h1>
-    </div>
-  </a>
-</li>
-
-<!--I hope you choke-->
-<li class="grid-item" data-jkit="[show:delay=2800;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/choke-icon.jpg" alt="I hope you choke sculpture thumbnail">
-  <a href="3d/choke.html">
-    <div class="grid-hover">
-      <h1>I hope you choke</h1>
-      <p>Ceiling fan, steel cable, Action</p>
-    </div>
-  </a>
-</li>
-
-<!--No meaning in any of this-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/118443300" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!-- Another track - Soft Sculpture -->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe width="250" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/239217880"></iframe>
-</li>
-
-<!--Engram/Digital Bath-->
-<li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/bath.jpg" alt="Digital Bath/Engram installation thumbnail">
-  <a href="3d/bath.html">
-    <div class="grid-hover">
-      <h1>Digital Bath/Engram</h1>
-      <p>Sculpture, Digital Projection, Installation</p>
-    </div>
-  </a>
-</li>
-
-<!--I know everything and Nothing - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/197475395" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--I'd never lie to you-->
-<li class="grid-item" data-jkit="[show:delay=700;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/lie.jpg" alt="I'd never lie to you sculpture thumbnail">
-  <a href="3d/lie.html">
-    <div class="grid-hover">
-      <h1>I'd never lie to you</h1>
-      <p>Wood, Sheetrock, Arrows, Action</p>
-    </div>
-  </a>
-</li>
-
-<!--Untitled-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/flat/untitled.jpg" alt="Untitled (an act of war) artwork thumbnail">
-  <a href="2d/untitled.html">
-    <div class="grid-hover">
-      <h1>Untitled (an act of war)</h1>
-    </div>
-  </a>
-</li>
-
-<!--There are as many days as there are nights-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe src="https://player.vimeo.com/video/80392530" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--no meaning-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/flat/post.jpg" alt="Banners poster thumbnail">
-  <a href="2d/banners.html">
-    <div class="grid-hover">
-      <h1>Banners</h1>
-    </div>
-  </a>
-</li>
-
-<!--a fair warning-->
-<li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
-  <a href="3d/warning.html">
-    <div class="grid-hover">
-      <h1>A fair warning</h1>
-      <p>Neon sign, Java program, Installation</p>
-    </div>
-  </a>
-</li>
-
-<!-- some more - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe width="250" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/234357178"></iframe>
-</li>
-
-<!--Stairs-->
-<li class="grid-item" data-jkit="[show:delay=2000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/save.jpg" alt="Red Stairs/Somebody please save us installation thumbnail">
-  <a href="3d/redstairs.html">
-    <div class="grid-hover">
-      <h1>Red Stairs/Somebody please save us</h1>
-      <p>Wood, Steel, Java Program, Control circuits/applause track, Action</p>
-    </div>
-  </a>
-</li>
-
-<!--I can't hear you-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe src="https://player.vimeo.com/video/118084325" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--Delay hasn't cost me a thing-->
-<li class="grid-item" data-jkit="[show:delay=1500;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/call.jpg" alt="Delay hasn't cost me anything sculpture thumbnail">
-  <a href="3d/call.html">
-    <div class="grid-hover">
-      <h1>Delay hasn't cost me anything</h1>
-      <p>Aluminum, Copper, Flourescents, Audio/Equip,emt, Sculpture</p>
-    </div>
-  </a>
-</li>
-
-<!--Responsibility in 2 acts, 1 song-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe src="https://player.vimeo.com/video/56168218" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--Nightstalker Re-Runs-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/flat/windows.jpg" alt="Nighstalker Re-Runs on Channel 4 collage thumbnail">
-  <a href="2d/stalker.html">
-    <div class="grid-hover">
-      <h1>Nighstalker Re-Runs on Channel 4</h1>
-    </div>
-  </a>
-</li>
-
-<!--If you take a shot at the king, you make sure you kill him-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/64396116" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!-- - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe width="250" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/233967499&auto_play=false&hide_related=true&show_user=true&visual=false"></iframe>
-</li>
-
-<!--Are you ready to fly-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/fly.jpg" alt="Are you ready to fly? installation thumbnail">
-  <a href="3d/fly.html">
-    <div class="grid-hover">
-      <h1>Are you ready to fly?</h1>
-      <p>Java program, Audio, Installation</p>
-    </div>
-  </a>
-</li>
-
-<!-- The truth is, I hate to tell you-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/flat/hate.jpg" alt="The truth is, I hate to tell you artwork thumbnail">
-  <a href="2d/hate.html">
-    <div class="grid-hover">
-      <h1>The truth is, I hate to tell you</h1>
-    </div>
-  </a>
-</li>
-
-<!--Something else - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500;animation=fade]">
-  <iframe width="250" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/233125013&auto_play=false&hide_related=true&show_user=true&visual=false"></iframe>
-</li>
-
-<!--I can't tell where to begin-->
-<li class="grid-item" data-jkit="[show:delay=2500;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/party.jpg" alt="I can't tell where to begin action piece thumbnail">
-  <a href="3d/party.html">
-    <div class="grid-hover">
-      <h1>I can't tell where to begin</h1>
-      <p>April 14, 2012, Action</p>
-    </div>
-  </a>
-</li>
-
-<!--Time to Bleed - Soft Sculpture-->
-<li class="grid-item" data-jkit="[show:delay=3000;speed=500]">
-  <iframe src="https://player.vimeo.com/video/197476645" width=“250” height=“420” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</li>
-
-<!--They're preparing for war -->
-<li class="grid-item" data-jkit="[show:delay=900;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/war_1.jpg" alt="They're preparing for war installation thumbnail">
-  <a href="3d/war.html">
-    <div class="grid-hover">
-      <h1>They're preparing for war</h1>
-      <p>Construction materials, Installation</p>
-    </div>
-  </a>
-</li>
-
-<!--A fair warning-->
-<li class="grid-item" data-jkit="[show:delay=2400;speed=500;animation=fade]">
-  <img loading="lazy" src="img/portfolio/3d/warning.jpg" alt="A fair warning neon installation thumbnail">
-  <a href="3d/warning.html">
-    <div class="grid-hover">
-      <h1>A fair warning</h1>
-      <p>Neon sign, Java program, Installation</p>
-    </div>
-  </a>
-</li>
-
-  <!--End of main content-->
-      </ul>
-  </div>
-  <!--Footer-->
-  <footer>
-    <div class="footer-margin">
-      <div class="social-footer">
-        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
-      </div>
-      <div class="copyright">© Copyright 2005-2024 BSeverns.com. CC SA 4.0</div>
+    <!-- TODO: Update studio cards with final links and copy. -->
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
     </div>
   </footer>
 </body>
-
-  <!--jquery things-->
-  <script src="js/jquery.min.js"></script>
-  <script src="js/jquery.easing.min.js"></script>
-  <script src="js/modernizr.custom.42534.js" type="text/javascript"></script>
-  <script src="js/jquery.waitforimages.js" type="text/javascript"></script>
-  <script src="js/typed.js" type="text/javascript"></script>
-  <script src="js/masonry.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/imagesloaded.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/jquery.jkit.1.2.16.min.js"></script>
-  <script src="js/script.js" type="text/javascript"></script>
-
-<script>
-  $('#button, #buttons').on('click', function() {
-    $(".opacity-nav").fadeToggle("slow", "linear"); /* Animation complete.*/
-  });
-</script>
-
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,116 +1,92 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
-  <title>B. Severns | Selected Works</title>
-  <meta name="description" content="Web Portfolio of Ben Severns, Minneapolis-based artist/educator ">
-  <meta name="keywords" content="art, Minneapolis, technology, postmodern, kinetic, glitch, photography, sculpture, drawing, art education, installation, protest, fine art, contemporary art, art installation, anti-art, sound art, error art, chance art, SoftSculpture, soft sculpture, techno-art, robot art, kinetic art, punk rock, noise music, newnow">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta name="author" content="B.Severns">
-  <link rel="icon" type="image/png" href="img/icon.png" />
-  <!--Style-->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,300,500,600,700,800,900,100,200"/>
-  <link rel="stylesheet" href="css/reset.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <!--
-  <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
-  <script src="js/tunnelSketch.js"></script>
-  -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact · Ben Severns</title>
+  <meta name="description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <link rel="canonical" href="https://bseverns.github.io/contact.html">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Contact · Ben Severns">
+  <meta property="og:description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <meta property="og:url" content="https://bseverns.github.io/contact.html">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Contact · Ben Severns">
+  <meta name="twitter:description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://bseverns.github.io/"},
+      {"@type":"ListItem","position":2,"name":"Contact","item":"https://bseverns.github.io/contact.html"}
+    ]
+  }
+  </script>
 </head>
-
 <body>
-  <!--Preloader-->
-  <div class="preloader" id="preloader">
-    <div class="item">
-      <div class="spinner">
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
       </div>
-    </div>
-  </div>
-
-  <!--nav buttons-->
-  <div class="opacity-nav">
-    <div class="menu-index" id="buttons" style="z-index:99999">
-      <i class="fa  fa-close"></i>
-    </div>
-
-    <ul class="menu-fullscreen">
-      <li><a href="index.html">Home/Portfolio</a></li>
-      <li><a href="/about/">About/CV</a></li>
-      <li><a href="contact.html">Contact</a></li>
-    </ul>
-  </div>
-
-  <!--Header image/menu-->
-  <header id="fullscreen">
-    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
-    <div class="menu-index" id="button">
-      <i class="fa fa-th"></i>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html" aria-current="page">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
-
-  <!--Content-->
-  <div class="content">
-    <div class="text-intro">
+  <main id="main" class="site-main" tabindex="-1">
+    <div class="container page-intro">
+      <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li aria-current="page">Contact</li>
+        </ol>
+      </nav>
       <h1>Contact</h1>
-      <p>Hello. I'd love to talk with you more about projects that I'm working on, projects you're thinking about, or things that you've seen recently that make you excited.<br />
-        The form below may or may not work at the moment. E mail me at b severns [at] mcad [dot] edu</p>
-      <form method="post" action="?" data-jkit="[form:validateonly=true]">
-        <div class="contact-one">
-          <p>
-            <label for="miniusername">Name:</label><br />
-            <input name="miniusername" id="miniusername" data-jkit="[validate:required=true;min=3;max=10;error=Please enter your username (3-10 characters)]">
-          </p>
-        </div>
-        <div class="contact-two">
-          <p>
-            <label for="miniemail">E-mail:</label><br />
-            <input name="miniemail" id="miniemail" data-jkit="[validate:required=true;strength=50;error=Please write your email]">
-          </p>
-        </div>
-        <div class="contact-three">
-          <p>
-            <label>Message:</label><br />
-            <textarea id="message" name="message"></textarea><br /><br />
-            <input class="button-submit" name="send" type="submit" value="SUBMIT" action="mail.php">
-          </p>
-        </div>
-      </form>
+      <p>I’m happy to connect about co-building, teaching collaborations, documentation strategy, or performances. Bots and scraper farms get bounced.</p>
     </div>
-    <br /><br /><br /><br /><br /><br /><br /><br />
-  </div>
 
-  <!--Footer-->
-  <footer>
-    <div class="footer-margin">
-      <div class="social-footer">
-        <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-        <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a>
+    <section class="contact-section" aria-labelledby="contact-direct">
+      <div class="container">
+        <h2 id="contact-direct">Reach me directly</h2>
+        <ul class="contact-list">
+          <li><a href="mailto:hello@bseverns.me">hello@bseverns.me</a> — best for project starts and resource requests.</li>
+          <li><a href="https://www.linkedin.com/in/bseverns">LinkedIn</a> — professional context, intros, references.</li>
+          <li><a href="https://github.com/bseverns">GitHub</a> — follow along with open tooling and documentation repos.</li>
+        </ul>
       </div>
-      <div class="copyright">© Copyright 2016 BSeverns.com. All Rights Reserved.</div>
+    </section>
+
+    <section class="contact-section" aria-labelledby="contact-media">
+      <div class="container">
+        <h2 id="contact-media">Media + press</h2>
+        <p>For coverage, quote checks, and audiovisual assets, start with the <a href="/press-kit.html">press kit</a>. It’s updated more often than third-party bios and never scrapes.</p>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html" aria-current="page">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
     </div>
   </footer>
-
-  <!--Scripts-->
-  <script src="js/jquery.min.js"></script>
-  <script src="js/jquery.easing.min.js"></script>
-  <script src="js/modernizr.custom.42534.js" type="text/javascript"></script>
-  <script src="js/jquery.waitforimages.js" type="text/javascript"></script>
-  <script src="js/typed.js" type="text/javascript"></script>
-  <script src="js/masonry.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/imagesloaded.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/jquery.jkit.1.2.16.min.js"></script>
-  <script src="js/script.js" type="text/javascript"></script>
-  <script>
-    $('#button, #buttons').on('click', function() {
-      $(".opacity-nav").fadeToggle("slow", "linear");
-      // Animation complete.
-    });
-  </script>
 </body>
-
 </html>

--- a/courses.html
+++ b/courses.html
@@ -1,125 +1,105 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
-  <title>B. Severns | Selected Works</title>
-  <meta name="description" content="Web Portfolio of Ben Severns, Minneapolis-based artist/educator ">
-  <meta name="keywords" content="art, Minneapolis, technology, postmodern, kinetic, glitch, photography, sculpture, drawing, art education, installation, protest, fine art, contemporary art, art installation, anti-art, sound art, error art, chance art, SoftSculpture, soft sculpture, techno-art, robot art, kinetic art, punk rock, noise music, newnow">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta name="author" content="B.Severns">
-  <link rel="icon" type="image/png" href="img/icon.png" />
-  <!--Style-->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,300,500,600,700,800,900,100,200"/>
-  <link rel="stylesheet" href="css/reset.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <!--
-  <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
-  <script src="js/tunnelSketch.js"></script>
-  -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Teaching projects · Ben Severns</title>
+  <meta name="description" content="Teaching work from Ben Severns: curricula, kits, and learning environments that support co-creation.">
+  <link rel="canonical" href="https://bseverns.github.io/courses.html">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Teaching projects · Ben Severns">
+  <meta property="og:description" content="Teaching work from Ben Severns: curricula, kits, and learning environments that support co-creation.">
+  <meta property="og:url" content="https://bseverns.github.io/courses.html">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Teaching projects · Ben Severns">
+  <meta name="twitter:description" content="Teaching work from Ben Severns: curricula, kits, and learning environments that support co-creation.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://bseverns.github.io/"},
+      {"@type":"ListItem","position":2,"name":"Teaching","item":"https://bseverns.github.io/courses.html"}
+    ]
+  }
+  </script>
 </head>
-
 <body>
-  <!--Preloader-->
-  <div class="preloader" id="preloader">
-    <div class="item">
-      <div class="spinner">
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
       </div>
-    </div>
-  </div>
-
-  <!--nav buttons-->
-  <div class="opacity-nav">
-    <div class="menu-index" id="buttons" style="z-index:99999">
-      <i class="fa  fa-close"></i>
-    </div>
-
-    <ul class="menu-fullscreen">
-      <li><a href="index.html">Home/Portfolio</a></li>
-      <li><a href="/about/">About/CV</a></li>
-      <li><a href="contact.html">Contact</a></li>
-    </ul>
-  </div>
-
-  <!--Header image/menu-->
-  <header id="fullscreen">
-    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
-    <div class="menu-index" id="button">
-      <i class="fa fa-th"></i>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html" aria-current="page">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
-
-  <!--Content-->
-  <div class="content">
-    <div class="text-intro">
-      <h1>Academic Portfolio</h1>
-      <p>Syllabi and assorted classroom experiments are simmering here. I'm keeping this corner honest by only listing the builds that actually live on this server.</p>
-      <ul class="syllabus-list">
-        <li><a href="/text/SP23_FDN131102_Foundation_ Media1_Severns.docx/">MCAD Foundation: Media 1</a> — a guided tour of MCAD's digital resources with hands-on work in video, sound, photography, and the critical language to talk about them.</li>
-        <li><a href="/text/SP23_FDN131203_Foundation_ Media2_Severns.docx/">MCAD Foundation: Media 2</a> — sustained experiments in observation, recording, editing, and multimedia storytelling that push beyond the Media 1 toolkit.</li>
-        <li><a href="/text/SP20_WMM308501_ExperimentalSoundDesign_Severns.docx/">MCAD Experimental Sound Design</a> — a hybrid workshop on making noise: capture audio, build performance rigs, and tinker with both DIY and high-tech sound manipulation.</li>
-        <li><a href="/text/SP19_FDN141105_IdeationandProcess_Severns.docx">MCAD Ideation and Process</a> — frameworks for developing ideas, charting process, and producing short projects with collaborative and solo critiques.</li>
-        <li><a href="/text/SP19_SC308201_SculptureStudio_ Arduino_Severns.docx">MCAD Sculpture Studio: Arduino</a> — open-source circuitry meets sculpture in a course on actuated objects, responsive installations, and communal code-sharing.</li>
-      </ul>
-      <p>Need the deep cuts or version history? Raid my <a href="https://github.com/bseverns/Syllabus">Syllabus GitHub repos</a> for syllabi source files, starter code, and other workshop debris.</p>
+  <main id="main" class="site-main" tabindex="-1">
+    <div class="container page-intro">
+      <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li aria-current="page">Teaching</li>
+        </ol>
+      </nav>
+      <h1>Teaching projects</h1>
+      <p>Learning environments, kits, and curricula that prioritize agency, consent, and reproducibility.</p>
     </div>
 
-    <!--
-
-
-
-
-
-
-
-
-
-
-NOTHING HERE BOSS
-
-
-
-
-
-
-
-
-
-
-      -->
-      
-      <!--Footer-->
-      <footer>
-        <div class="footer-margin">
-          <div class="social-footer">
-            <a href="https://www.facebook.com/bseverns"><i class="fa fa-facebook"></i></a>
-            <!--<a href="https://www.twitter.com/b_severns"><i class="fa fa-twitter"></i></a>-->
-            <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
-            <p>Or you can contact me at severns 3 {at} {a mail service from daddy-Goog}</p>
-          </div>
-          <div class="copyright">© Copyright 2005-2022 BSeverns.com. All Rights Reserved.</div>
+    <div class="container card-grid">
+      <article class="card">
+        <div class="card-visual" data-src="/img/portfolio/flat/post.jpg" data-alt="Workshop tables laid out with electronics kits"></div>
+        <div class="card-body">
+          <h2>STEAM lab quick-starts</h2>
+          <p>Station cards and build recipes that get K–12 learners into fabrication safely and fast.</p>
+          <!-- TODO: Link the resource bundle once published. -->
+          <span class="card-link pending" role="text">Resource bundle coming soon</span>
         </div>
-      </footer>
-
-      <!--jquery things-->
-      <script src="js/jquery.min.js"></script>
-      <script src="js/jquery.easing.min.js"></script>
-      <script src="js/modernizr.custom.42534.js" type="text/javascript"></script>
-      <script src="js/jquery.waitforimages.js" type="text/javascript"></script>
-      <script src="js/typed.js" type="text/javascript"></script>
-      <script src="js/masonry.pkgd.min.js" type="text/javascript"></script>
-      <script src="js/imagesloaded.pkgd.min.js" type="text/javascript"></script>
-      <script src="js/jquery.jkit.1.2.16.min.js"></script>
-      <script src="js/script.js" type="text/javascript"></script>
-
-    <script>
-      $('#button, #buttons').on('click', function() {
-        $(".opacity-nav").fadeToggle("slow", "linear"); /* Animation complete.*/
-      });
-    </script>
-
-    </body>
-    </html>
+      </article>
+      <article class="card">
+        <div class="card-visual" data-src="/img/logo/self_about.jpg" data-alt="Ben Severns facilitating a media arts workshop"></div>
+        <div class="card-body">
+          <h2>Consent-forward sensing workshop</h2>
+          <p>Curriculum that reframes data capture around permission, opt-out defaults, and transparent logs.</p>
+          <!-- TODO: Drop in the full curriculum link when it ships. -->
+          <span class="card-link pending" role="text">Curriculum drop coming soon</span>
+        </div>
+      </article>
+      <article class="card">
+        <div class="card-visual" data-src="/img/portfolio/3d/party.jpg" data-alt="Projection scene from a collaborative class build"></div>
+        <div class="card-body">
+          <h2>Augsburg media systems</h2>
+          <p>Adjunct course emphasizing assumption ledgers and mapping manifests for every build.</p>
+          <!-- TODO: Replace with final syllabus link. -->
+          <span class="card-link pending" role="text">Syllabus in edit</span>
+        </div>
+      </article>
+    </div>
+    <!-- TODO: Update teaching cards with final links and copy. -->
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/css/site.css
+++ b/css/site.css
@@ -1,0 +1,395 @@
+:root {
+  color-scheme: light dark;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #fdfdfc;
+  --fg: #1a1a1a;
+  --muted: #4b4b4b;
+  --border: #d0d0d0;
+  --accent: #1e66f5;
+  --accent-contrast: #ffffff;
+  --surface: #ffffff;
+  --surface-muted: #f1f1f0;
+  --focus: #ff7a18;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1014;
+    --fg: #f4f4f4;
+    --muted: #bbbbbb;
+    --border: #2d2f39;
+    --accent: #7aa2ff;
+    --accent-contrast: #050608;
+    --surface: #161821;
+    --surface-muted: #1f2230;
+    --focus: #f59e0b;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-family);
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.2em;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 1rem;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.3rem;
+  transition: top 0.2s ease;
+  z-index: 1000;
+}
+
+.skip-link:focus-visible {
+  top: 1rem;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.brand-link {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: inherit;
+  text-decoration: none;
+}
+
+.primary-nav ul,
+.site-footer nav ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a,
+.site-footer nav a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus-visible,
+.site-footer nav a:hover,
+.site-footer nav a:focus-visible {
+  text-decoration: underline;
+}
+
+.site-main {
+  outline: none;
+}
+
+.container {
+  width: min(100% - 2rem, 1024px);
+  margin: 0 auto;
+}
+
+.hero {
+  background: var(--surface);
+  padding: 4rem 0;
+}
+
+.hero-inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-copy h1 {
+  font-size: clamp(2.25rem, 4vw + 1rem, 3.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.hero-subhead {
+  font-size: 1.125rem;
+  color: var(--muted);
+  max-width: 32ch;
+}
+
+.hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.6rem;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.button.secondary {
+  background: transparent;
+  border-color: var(--border);
+  color: inherit;
+}
+
+.button:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.hero-visual,
+.card-visual,
+.asset-preview {
+  position: relative;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  min-height: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-visual,
+.asset-preview {
+  min-height: 200px;
+}
+
+.ph {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  border: 1px dashed var(--border);
+  background: repeating-linear-gradient(135deg, transparent 0, transparent 12px, rgba(0,0,0,0.05) 12px, rgba(0,0,0,0.05) 24px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  padding: 1rem;
+  text-align: center;
+}
+
+.pillars {
+  padding: 3rem 0;
+}
+
+.card-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.card-body h2,
+.card-body h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.card-body p {
+  margin: 0 0 1rem;
+  color: var(--muted);
+}
+
+.card-link {
+  font-weight: 600;
+}
+
+.card-link.pending {
+  color: var(--muted);
+  cursor: default;
+  text-decoration: none;
+}
+
+.whats-new,
+.archive-note,
+.contact-section,
+.press-section {
+  padding: 3rem 0;
+}
+
+.news-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.news-meta {
+  display: block;
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+.page-intro {
+  padding: 3rem 0 1rem;
+}
+
+.breadcrumb ol {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+  padding: 0;
+  font-size: 0.9rem;
+}
+
+.breadcrumb li::after {
+  content: "/";
+  margin-left: 0.5rem;
+  color: var(--muted);
+}
+
+.breadcrumb li:last-child::after {
+  content: "";
+}
+
+.quick-facts,
+.contact-list,
+.asset-status-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.asset-status-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px dashed var(--border);
+  border-radius: 0.45rem;
+  padding: 0.75rem 1rem;
+}
+
+.asset-path {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+}
+
+.asset-status {
+  font-weight: 600;
+}
+
+.asset-note {
+  margin: 0.5rem 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.asset-status[data-state="present"] {
+  color: #0b8f3c;
+}
+
+.asset-status[data-state="missing"] {
+  color: var(--muted);
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  margin-top: 4rem;
+}
+
+.footer-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 0;
+}
+
+.footer-inner nav ul {
+  flex-wrap: wrap;
+}
+
+@media (min-width: 768px) {
+  .footer-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.hero-visual img,
+.card-visual img,
+.asset-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.archive-banner {
+  position: relative;
+  z-index: 999;
+  background: #111827;
+  color: #f9fafb;
+  padding: 0.6rem 1rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.archive-banner a {
+  color: #facc15;
+  text-decoration: underline;
+}

--- a/index.html
+++ b/index.html
@@ -1,139 +1,136 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
-  <title>B. Severns | Selected Works</title>
-  <meta name="description" content="Web Portfolio of Ben Severns, Minneapolis-based artist/educator ">
-  <meta name="keywords" content="art, Minneapolis, technology, postmodern, kinetic, glitch, photography, sculpture, drawing, art education, installation, protest, fine art, contemporary art, art installation, anti-art, sound art, error art, chance art, Soft Sculpture, soft sculpture, techno-art, robot art, kinetic art, punk rock, noise music, new now, BS">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta name="author" content="B.Severns">
-  <link rel="icon" type="image/png" href="img/icon.png" />
-  <!--Style-->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,300,500,600,700,800,900,100,200"/>
-  <link rel="stylesheet" href="css/reset.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/style-responsive.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <!--
-  <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js"></script>
-  <script src="js/tunnelSketch.js"></script>
-  -->
-</head>
-
-<body>
-
-  <!--google-->
-  <script>
-    (function(i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r;
-      i[r] = i[r] || function() {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date();
-      a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0];
-      a.async = 1;
-      a.src = g;
-      m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', 'UA-91606700-1', 'auto');
-    ga('send', 'pageview');
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ben Severns · Tools, scenes, and learning environments</title>
+  <meta name="description" content="Artist–educator Ben Severns builds tools, scenes, and learning environments with documentation-first systems.">
+  <link rel="canonical" href="https://bseverns.github.io/">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Ben Severns · Tools, scenes, and learning environments">
+  <meta property="og:description" content="Artist–educator Ben Severns builds tools, scenes, and learning environments with documentation-first systems.">
+  <meta property="og:url" content="https://bseverns.github.io/">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ben Severns · Tools, scenes, and learning environments">
+  <meta name="twitter:description" content="Artist–educator Ben Severns builds tools, scenes, and learning environments with documentation-first systems.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ben Severns",
+    "url":"https://bseverns.github.io/",
+    "jobTitle":"Artist–Educator",
+    "description":"Artist–educator building tools, scenes, and learning environments.",
+    "sameAs":["https://github.com/bseverns","https://bseverns.github.io/","https://www.linkedin.com/in/bseverns","https://bbss.bandcamp.com/","https://www.instagram.com/42_0822.86/","https://www.mcad.edu/faculty-alumni/ben-severns","https://www.creatempls.org/about"]
+  }
   </script>
-
-  <!--Preloader-->
-  <div class="preloader" id="preloader">
-    <div class="item">
-      <div class="spinner">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
       </div>
-    </div>
-  </div>
-
-  <!--nav buttons-->
-  <div class="opacity-nav">
-    <div class="menu-index" id="buttons" style="z-index:99999">
-      <i class="fa  fa-close"></i>
-    </div>
-
-    <ul class="menu-fullscreen">
-      <li><a href="/about/">About/CV</a></li>
-      <li><a href="contact.html">Contact</a></li>
-    </ul>
-  </div>
-
-  <!--Header image/menu-->
-  <header id="fullscreen">
-    <img src="img/front/banner.gif" alt="glitchy rainbow banner">
-    <div class="menu-index" id="button">
-      <i class="fa fa-th"></i>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
-
-  <!--Content-->
-  <div class="content" id="ajax-content">
-    <div class="text-intro" id="site-type">
-      <h1>B.Severns</h1>
-      <p class="tagline">Click into the academic or studio worlds below; hover for hints, dive for details.</p>
-      <h1 class="typewrite"><span></span></h1>
-    </div>
-
-<!--JS animation layer -->
-
-    <!--Portfolio grid-->
-    <ul class="portfolio-grid">
-        <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-      <img src="img/icon.png" alt="placeholder cube icon"> <!--To be fixed -->
-          <a href="courses.html">
-            <div class="grid-hover">
-                <h2>Academic Portfolio</h2>
-                <p>Course syllabi and other materials</p>
-              </div>
-          </a>
-        </li>
-
-            <li class="grid-item" data-jkit="[show:delay=1000;speed=500;animation=fade]">
-            <img src="img/icon.png" alt="placeholder cube icon"> <!--To be fixed -->
-              <a href="art.html">
-                <div class="grid-hover">
-                    <h2>Studio Portfolio</h2>
-                    <p>Media and experiments with varied documentation</p>
-                  </div>
-              </a>
-            </li>
-
-            <!--a generative p5.js thing here-->
-
-    <!--End of main content-->
-    </ul>
-  </div>
-
-  <!--Footer-->
-  <footer>
-    <div class="footer-margin">
-      <div class="social-footer">
-        <a href="https://www.instagram.com/0822.86/"><i class="fa fa-instagram"></i></a><br>
-        <!--Github &&reddit? && video sharing && ??? -->
+  <main id="main" class="site-main" tabindex="-1">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow">Artist–educator in Minneapolis, MN</p>
+          <h1 id="hero-title">Tools, scenes, and learning environments.</h1>
+          <p class="hero-subhead">Systems-first practice with documentation you can audit, adapt, and teach from.</p>
+          <div class="hero-ctas">
+            <a class="button" href="/art.html">Explore Studio</a>
+            <a class="button secondary" href="/courses.html">Explore Teaching</a>
+          </div>
+        </div>
+        <div class="hero-visual" data-hero="true" data-src="/img/front/context.jpg" data-alt="Analog synth setup with projection work in progress"></div>
       </div>
-      <div class="copyright">© Copyright 2005-2024 BSeverns.com. CC SA 4.0</div>
+    </section>
+
+    <section class="pillars" aria-labelledby="pillars-title">
+      <div class="container">
+        <h2 id="pillars-title">Three pillars</h2>
+        <div class="card-grid">
+          <article class="card pillar">
+            <div class="card-body">
+              <h3>Tools</h3>
+              <p>Open instruments, kits, and supporting docs designed for remix, repair, and co-learning.</p>
+              <a class="card-link" href="https://github.com/bseverns/MOARkNOBS-42">Read the MOARkNOBS-42 build</a>
+            </div>
+          </article>
+          <article class="card pillar">
+            <div class="card-body">
+              <h3>Scenes</h3>
+              <p>Installations and performances that foreground consent-forward sensing and agency.</p>
+              <a class="card-link" href="/art.html">Browse studio notes</a>
+            </div>
+          </article>
+          <article class="card pillar">
+            <div class="card-body">
+              <h3>Learning</h3>
+              <p>Curricula, station cards, and quick-start kits that turn curiosity into replicable skill.</p>
+              <a class="card-link" href="/courses.html">View teaching projects</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="whats-new" aria-labelledby="news-title">
+      <div class="container">
+        <h2 id="news-title">What’s new</h2>
+        <ul class="news-list">
+          <li>
+            <strong>Mini-lab toolkit iteration.</strong>
+            <span class="news-meta">Testing updated sensor harness workflow.</span>
+          </li>
+          <li>
+            <strong>MOARkNOBS-42 performance notes.</strong>
+            <span class="news-meta">Documenting latency audits for the current rig.</span>
+          </li>
+          <li>
+            <strong>Consent-forward sensing workshop.</strong>
+            <span class="news-meta">Refining prompts and open documentation sets.</span>
+          </li>
+        </ul>
+        <!-- TODO: Update "What’s new" entries as projects ship. -->
+      </div>
+    </section>
+
+    <section class="archive-note" aria-labelledby="archive-note-title">
+      <div class="container">
+        <h2 id="archive-note-title">Note on older pages</h2>
+        <p>Legacy write-ups stick around for transparency. An archive banner points back here so you always know where the current work lives.</p>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
     </div>
   </footer>
 </body>
-
-  <!--jquery things-->
-  <script src="js/jquery.min.js"></script>
-  <script src="js/jquery.easing.min.js"></script>
-  <script src="js/modernizr.custom.42534.js" type="text/javascript"></script>
-  <script src="js/jquery.waitforimages.js" type="text/javascript"></script>
-  <script src="js/typed.js" type="text/javascript"></script>
-  <script src="js/masonry.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/imagesloaded.pkgd.min.js" type="text/javascript"></script>
-  <script src="js/jquery.jkit.1.2.16.min.js"></script>
-  <script src="js/script.js" type="text/javascript"></script>
-
-<script>
-  $('#button, #buttons').on('click', function() {
-    $(".opacity-nav").fadeToggle("slow", "linear"); /* Animation complete.*/
-  });
-</script>
-
 </html>

--- a/js/archive-banner.js
+++ b/js/archive-banner.js
@@ -1,0 +1,46 @@
+(function () {
+  function injectStyles() {
+    if (document.getElementById('archive-banner-style')) {
+      return;
+    }
+    const style = document.createElement('style');
+    style.id = 'archive-banner-style';
+    style.textContent = '.archive-banner{position:relative;z-index:999;background:#111827;color:#f9fafb;padding:0.6rem 1rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-size:0.95rem;letter-spacing:0.02em;} .archive-banner a{color:#facc15;text-decoration:underline;font-weight:600;} .archive-banner a:focus-visible{outline:3px solid #f97316;outline-offset:2px;}';
+    document.head.appendChild(style);
+  }
+
+  function insertBanner() {
+    if (document.querySelector('.archive-banner')) {
+      return;
+    }
+    injectStyles();
+    const banner = document.createElement('div');
+    banner.className = 'archive-banner';
+    banner.setAttribute('role', 'region');
+    banner.setAttribute('aria-label', 'Archive notice');
+
+    const message = document.createElement('span');
+    message.textContent = 'Archived. ';
+
+    const link = document.createElement('a');
+    link.href = '/';
+    link.textContent = 'New work → home';
+    link.setAttribute('aria-label', 'New work, return to the homepage');
+
+    banner.appendChild(message);
+    banner.appendChild(link);
+
+    const body = document.body;
+    if (body.firstChild) {
+      body.insertBefore(banner, body.firstChild);
+    } else {
+      body.appendChild(banner);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', insertBanner);
+  } else {
+    insertBanner();
+  }
+})();

--- a/js/site.js
+++ b/js/site.js
@@ -1,0 +1,177 @@
+(function () {
+  const OG_IMAGE = '/img/social/og-banner.jpg';
+  const FALLBACK_IMAGE = '/img/front/context.jpg';
+
+  function setCurrentYear() {
+    const node = document.querySelector('[data-current-year]');
+    if (node) {
+      node.textContent = String(new Date().getFullYear());
+    }
+  }
+
+  function bindSkipLinkFocus() {
+    const skipLink = document.querySelector('.skip-link');
+    const main = document.getElementById('main');
+    if (!skipLink || !main) {
+      return;
+    }
+
+    skipLink.addEventListener('click', function (event) {
+      event.preventDefault();
+      main.setAttribute('tabindex', '-1');
+      main.focus({ preventScroll: false });
+      if (typeof main.scrollIntoView === 'function') {
+        main.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  }
+
+  async function requestHead(src) {
+    if (typeof fetch !== 'function') {
+      return false;
+    }
+
+    try {
+      const response = await fetch(src, { method: 'HEAD' });
+      return response.ok;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async function conditionallyRenderImage(options) {
+    const { mount, src, alt, className, width, height } = options || {};
+    if (!mount || !src) {
+      return;
+    }
+
+    if (mount.dataset.rendered === 'true') {
+      return;
+    }
+
+    mount.innerHTML = '';
+    const friendlyAlt = alt || 'Image';
+    const ok = await requestHead(src);
+
+    if (ok) {
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = friendlyAlt;
+      img.decoding = 'async';
+      img.loading = 'lazy';
+      if (className) {
+        img.className = className;
+      }
+      if (typeof width === 'number') {
+        img.width = width;
+      }
+      if (typeof height === 'number') {
+        img.height = height;
+      }
+      mount.appendChild(img);
+    } else {
+      const fallbackOk = await requestHead(FALLBACK_IMAGE);
+
+      if (fallbackOk) {
+        const fallbackImg = document.createElement('img');
+        fallbackImg.src = FALLBACK_IMAGE;
+        fallbackImg.alt = friendlyAlt + ' (fallback documentation image)';
+        fallbackImg.decoding = 'async';
+        fallbackImg.loading = 'lazy';
+        if (className) {
+          fallbackImg.className = className;
+        }
+        if (typeof width === 'number') {
+          fallbackImg.width = width;
+        }
+        if (typeof height === 'number') {
+          fallbackImg.height = height;
+        }
+        mount.appendChild(fallbackImg);
+      } else {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'ph';
+        placeholder.setAttribute('role', 'img');
+        placeholder.setAttribute('aria-label', friendlyAlt + ' (placeholder)');
+        placeholder.textContent = 'Image placeholder';
+        mount.appendChild(placeholder);
+      }
+    }
+
+    mount.dataset.rendered = 'true';
+  }
+
+  async function renderStatusBadge(el, path) {
+    if (!el || !path) {
+      return;
+    }
+
+    const status = el.querySelector('.asset-status');
+    const existingPath = el.querySelector('.asset-path');
+    const ok = await requestHead(path);
+
+    if (ok) {
+      if (existingPath) {
+        const link = document.createElement('a');
+        link.href = path;
+        link.textContent = existingPath.textContent || path;
+        link.className = 'asset-path';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        existingPath.replaceWith(link);
+      }
+      if (status) {
+        status.textContent = '✅ Present';
+        status.dataset.state = 'present';
+      }
+    } else if (status) {
+      status.textContent = '🕘 Not yet added';
+      status.dataset.state = 'missing';
+    }
+  }
+
+  function mountHeroImage() {
+    const hero = document.querySelector('.hero-visual[data-hero="true"]');
+    if (!hero) {
+      return;
+    }
+    const src = hero.getAttribute('data-src') || OG_IMAGE;
+    const alt = hero.getAttribute('data-alt') || 'Hero image';
+    conditionallyRenderImage({ mount: hero, src, alt, width: hero.clientWidth || undefined, height: hero.clientHeight || undefined });
+  }
+
+  function mountOtherImages() {
+    const mounts = document.querySelectorAll('[data-src]:not([data-hero="true"])');
+    mounts.forEach(function (mount) {
+      const src = mount.getAttribute('data-src');
+      const alt = mount.getAttribute('data-alt') || 'Project image';
+      conditionallyRenderImage({ mount, src, alt });
+    });
+  }
+
+  function hydrateAssetStatuses() {
+    const items = document.querySelectorAll('[data-asset-status]');
+    items.forEach(function (item) {
+      const path = item.getAttribute('data-path');
+      renderStatusBadge(item, path);
+    });
+  }
+
+  function init() {
+    setCurrentYear();
+    bindSkipLinkFocus();
+    mountHeroImage();
+    mountOtherImages();
+    hydrateAssetStatuses();
+  }
+
+  window.conditionallyRenderImage = conditionallyRenderImage;
+  window.renderStatusBadge = renderStatusBadge;
+  window.mountHeroImage = mountHeroImage;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/press-kit.html
+++ b/press-kit.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Press kit · Ben Severns</title>
+  <meta name="description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <link rel="canonical" href="https://bseverns.github.io/press-kit.html">
+  <link rel="stylesheet" href="/css/site.css">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Press kit · Ben Severns">
+  <meta property="og:description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <meta property="og:url" content="https://bseverns.github.io/press-kit.html">
+  <meta property="og:image" content="/img/social/og-banner.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Press kit · Ben Severns">
+  <meta name="twitter:description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="/js/site.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://bseverns.github.io/"},
+      {"@type":"ListItem","position":2,"name":"Press kit","item":"https://bseverns.github.io/press-kit.html"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="Ben Severns home">Ben Severns</a>
+      </div>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html" aria-current="page">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main id="main" class="site-main" tabindex="-1">
+    <div class="container page-intro">
+      <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li aria-current="page">Press kit</li>
+        </ol>
+      </nav>
+      <h1>Press kit</h1>
+      <p>Use these bios and quick facts as-is. Reach out before quoting if you need a bespoke angle or accessibility format.</p>
+    </div>
+
+    <section class="press-section" aria-labelledby="bio-short">
+      <div class="container">
+        <h2 id="bio-short">Bio (100 words)</h2>
+        <p>Ben Severns is a Minneapolis artist–educator who builds tools, scenes, and learning environments.
+His systems-first practice spans open instruments like MOARkNOBS-42, consent-forward sensing projects,
+and practical curricula for K–12 and college learners. As faculty/adjunct, he has taught at MCAD and Augsburg;
+as Educational Equipment &amp; Services Lead at createMPLS, he stewards large inventories and turns curiosity into skill.
+Severns documents like a researcher—assumption ledgers, mapping manifests, reproducible builds—so others can adapt,
+audit, and play. He performs and releases music as B_S_. More: bseverns.github.io · github.com/bseverns · bbss.bandcamp.com</p>
+      </div>
+    </section>
+
+    <section class="press-section" aria-labelledby="bio-long">
+      <div class="container">
+        <h2 id="bio-long">Bio (300 words)</h2>
+        <p>Ben Severns is a systems-level educator–artist based in Minneapolis.
+He designs and publishes instruments, installations, and learning environments that invite others to build with him.
+His open-hardware instrument MOARkNOBS-42 pairs a Teensy-based brain with auditable documentation—assumption ledgers,
+mapping manifests, and latency bench scripts—so claims about feel, access, and ethics stay reproducible.
+Severns’s studio work leans consent-forward: detection-only kiosks, room-playing media pieces, and small provocations that
+foreground agency and documentation as part of the artwork.</p>
+        <p>He teaches across institutions (MCAD, Augsburg) and leads equipment/services for createMPLS, developing practical kits,
+station cards, and quick-starts that make STEAM approachable for K–12 and community learners.
+As B_S_, he performs and releases long-form, glitch-lit sound collages.
+Unifying these threads is a simple measure of success: how well other people create with the tools and recipes he leaves behind.</p>
+      </div>
+    </section>
+
+    <section class="press-section" aria-labelledby="quick-facts">
+      <div class="container">
+        <h2 id="quick-facts">Quick facts</h2>
+        <ul class="quick-facts">
+          <li>Location: Minneapolis, MN</li>
+          <li>Roles: Artist–Educator; Educational Equipment &amp; Services Lead (createMPLS)</li>
+          <li>Anchor project: MOARkNOBS-42 (open instrument)</li>
+          <li>Canonical handle: @bseverns</li>
+          <li>Links: bseverns.github.io · github.com/bseverns · bbss.bandcamp.com</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="press-section" aria-labelledby="image-drop-points">
+      <div class="container">
+        <h2 id="image-drop-points">Image drop points (optional)</h2>
+        <p>Supply press-friendly imagery at these paths and the site will surface them automatically. No upload? The status stays in “Not yet added” mode.</p>
+        <p class="asset-note" role="note">Status badges update after a quick HEAD request—no heavy downloads, just enough to confirm the files exist.</p>
+        <ul class="asset-status-list">
+          <li data-asset-status data-path="/img/press/headshot.jpg">
+            <span class="asset-path">/img/press/headshot.jpg</span>
+            <span class="asset-status" aria-live="polite">Checking…</span>
+          </li>
+          <li data-asset-status data-path="/img/social/og-banner.jpg">
+            <span class="asset-path">/img/social/og-banner.jpg</span>
+            <span class="asset-status" aria-live="polite">Checking…</span>
+          </li>
+          <li data-asset-status data-path="/img/studio/studio-1.jpg">
+            <span class="asset-path">/img/studio/studio-1.jpg</span>
+            <span class="asset-status" aria-live="polite">Checking…</span>
+          </li>
+          <li data-asset-status data-path="/img/install/install-1.jpg">
+            <span class="asset-path">/img/install/install-1.jpg</span>
+            <span class="asset-status" aria-live="polite">Checking…</span>
+          </li>
+        </ul>
+        <div class="asset-preview" data-src="/img/press/headshot.jpg" data-alt="Portrait of Ben Severns"></div>
+      </div>
+    </section>
+
+    <section class="press-section" aria-labelledby="press-contact">
+      <div class="container">
+        <h2 id="press-contact">Press contact</h2>
+        <p>Email <a href="mailto:hello@bseverns.me">hello@bseverns.me</a> for interview coordination. For more context, see the <a href="/contact.html">contact page</a>.</p>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <p>&copy; <span data-current-year></span> Ben Severns. Systems for builders.</p>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html" aria-current="page">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://bseverns.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,7 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+ <url><loc>https://bseverns.github.io/</loc><lastmod>2025-10-03</lastmod></url>
+ <url><loc>https://bseverns.github.io/art.html</loc><lastmod>2025-10-03</lastmod></url>
+ <url><loc>https://bseverns.github.io/courses.html</loc><lastmod>2025-10-03</lastmod></url>
+ <url><loc>https://bseverns.github.io/press-kit.html</loc><lastmod>2025-10-03</lastmod></url>
+ <url><loc>https://bseverns.github.io/contact.html</loc><lastmod>2025-10-03</lastmod></url>
+</urlset>

--- a/tools/attach-archive-banner.js
+++ b/tools/attach-archive-banner.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const HOMEPAGE_URL = 'https://bseverns.github.io/';
+const CORE_PAGES = new Set([
+  path.join(ROOT, 'index.html'),
+  path.join(ROOT, 'art.html'),
+  path.join(ROOT, 'courses.html'),
+  path.join(ROOT, 'press-kit.html'),
+  path.join(ROOT, 'contact.html'),
+  path.join(ROOT, '404.html')
+]);
+const SKIP_DIRS = new Set(['.git', 'node_modules', '_site', '_build']);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+    if (SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function ensureCanonical(html) {
+  if (/rel=["']canonical["']/i.test(html)) {
+    return { html, changed: false };
+  }
+  const headClose = html.match(/<\/head>/i);
+  if (!headClose) {
+    return { html, changed: false };
+  }
+  const index = headClose.index;
+  const insertion = `  <link rel="canonical" href="${HOMEPAGE_URL}">\n`;
+  const nextHtml = html.slice(0, index) + insertion + html.slice(index);
+  return { html: nextHtml, changed: true };
+}
+
+function ensureBannerScript(html) {
+  if (/archive-banner\.js/i.test(html)) {
+    return { html, changed: false };
+  }
+  const bodyClose = html.match(/<\/body>/i);
+  if (!bodyClose) {
+    return { html, changed: false };
+  }
+  const index = bodyClose.index;
+  const insertion = `  <script src="/js/archive-banner.js" defer></script>\n`;
+  const nextHtml = html.slice(0, index) + insertion + html.slice(index);
+  return { html: nextHtml, changed: true };
+}
+
+function processFile(filePath) {
+  if (CORE_PAGES.has(filePath)) {
+    return;
+  }
+  const original = fs.readFileSync(filePath, 'utf8');
+  let html = original;
+  let touched = false;
+
+  const canonicalResult = ensureCanonical(html);
+  if (canonicalResult.changed) {
+    html = canonicalResult.html;
+    touched = true;
+  }
+
+  const scriptResult = ensureBannerScript(html);
+  if (scriptResult.changed) {
+    html = scriptResult.html;
+    touched = true;
+  }
+
+  if (touched) {
+    fs.writeFileSync(filePath, html, 'utf8');
+    console.log(`Patched ${path.relative(ROOT, filePath)}`);
+  }
+}
+
+function main() {
+  const targets = walk(ROOT);
+  targets.forEach(processFile);
+}
+
+main();


### PR DESCRIPTION
## Summary
- replace the homepage with a focused three-pillar landing, companion studio/teaching pages, and refreshed contact/404 views
- add a single CSS/JS stack that handles responsive layout, accessibility, JSON-LD metadata, and conditional image/asset checks
- introduce press-kit enhancements, sitemap/robots, an archive banner script, and documentation for maintaining legacy pages
- swap placeholder media for in-repo assets, add a documented fallback image path, and tuck visible TODO anchors into comments
- tighten corner radii across interactive shells and card mounts for a sharper visual read

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68df36db8b8083259824c50c0afc2082