### PR TITLE
Add CTA links to teaching and studio pages

### DIFF
--- a/studio.md
+++ b/studio.md
@@ -5,6 +5,11 @@ seo_description: "Selected studio projects by Ben Severns"
 ---
 # Studio Portfolio
 <p>Hover or tap a card to get the gist; click through for the full noise.</p>
+<div class="cta">
+  <a class="btn secondary" href="/#archive-note-title">
+    Dig through the archive stacks ↗
+  </a>
+</div>
 <div class="cards">
 {% assign items = site.projects | sort: "year" | reverse %}
 {% for item in items %}{% include card.html item=item %}{% endfor %}

--- a/teaching.md
+++ b/teaching.md
@@ -6,6 +6,11 @@ seo_description: "Teaching portfolio and course briefs"
 # Academic Portfolio
 <p>Syllabi and assorted classroom experiments are simmering here. Check back while the dust settles.</p>
 <p>Sample syllabi, briefs, and outcomes. Full materials live at <a href="https://github.com/bseverns/Syllabus">github.com/bseverns/Syllabus</a>.</p>
+<div class="cta">
+  <a class="btn secondary" href="https://github.com/bseverns/Syllabus">
+    Raid the full syllabus repo ↗
+  </a>
+</div>
 <div class="cards">
 {% assign items = site.teaching | sort: "updated" | reverse %}
 {% for item in items %}{% include card.html item=item %}{% endfor %}


### PR DESCRIPTION
## Summary
- add a CTA on the teaching page that points directly to the syllabus GitHub repository
- surface the legacy archive from the studio page with a CTA linking to the archive note on the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb387ac5c83258f206f4ca46e0d7b