### PR TITLE
Align default layout with homepage structure

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,8 @@
 <!-- TODO: add default og image at assets/og-default.png -->
 <meta property="og:image" content="{{ page.og_image | default: '/assets/og-default.png' | relative_url }}">
 <meta name="twitter:card" content="summary_large_image">
-<link rel="stylesheet" href="{{ '/assets/site.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/site.css' | relative_url }}">
+<script defer src="{{ '/js/site.js' | relative_url }}"></script>
 
 {% if page.noindex %}
 <meta name="robots" content="noindex, noarchive, noimageindex">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,18 +1,39 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   {% include head.html %}
-  {% if page.noindex %}<meta name="robots" content="noindex,nofollow">{% endif %}
 </head>
 <body>
-<header class="site-head">
-  <nav>
-    {% for link in site.data.navigation %}
-      <a href="{{ link.url | relative_url }}">{{ link.title }}</a>
-    {% endfor %}
-  </nav>
-</header>
-<main id="content">{{ content }}</main>
-{% include footer.html %}
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="/" class="brand-link" aria-label="{{ site.title }} home">{{ site.title }}</a>
+      </div>
+      <nav aria-label="Primary" class="primary-nav">
+        <ul>
+          <li><a href="/art.html">Studio</a></li>
+          <li><a href="/courses.html">Teaching</a></li>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main id="main" class="site-main" tabindex="-1">
+    {{ content }}
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <div>© <span id="yr"></span> {{ site.title }} — <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.</div>
+      <nav aria-label="Footer">
+        <ul>
+          <li><a href="/press-kit.html">Press kit</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="/sitemap.xml">Sitemap</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the default layout to reuse the homepage skip link, header, and footer markup for consistent navigation and ARIA labeling
- point the shared head include at /css/site.css and load the shared site.js bundle so interior pages inherit the same visual system and skip-link behavior

## Testing
- not run (local Jekyll tooling is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfb898753c83258e62a83e5bb88870