### PR TITLE
Add front matter metadata to research notebooks

### DIFF
--- a/research/Documentation_Ethics_Me.md
+++ b/research/Documentation_Ethics_Me.md
@@ -1,3 +1,9 @@
+---
+title: "Documentation, Ethics & Meta-Research"
+layout: default
+permalink: /research/Documentation_Ethics_Me/
+---
+
 <!-- Filename: 6_Documentation_Ethics_MetaResearch.md -->
 # 6) Documentation, Ethics & Meta-Research
 

--- a/research/Fabrication_Systems_Met.md
+++ b/research/Fabrication_Systems_Met.md
@@ -1,3 +1,9 @@
+---
+title: "Fabrication & Systems as Artistic Method"
+layout: default
+permalink: /research/Fabrication_Systems_Met/
+---
+
 <!-- Filename: 7_Fabrication_Systems_Method.md -->
 # 7) Fabrication & Systems as Artistic Method
 

--- a/research/Generative_AV_Performan.md
+++ b/research/Generative_AV_Performan.md
@@ -1,3 +1,9 @@
+---
+title: "Generative A/V & Performance Tools"
+layout: default
+permalink: /research/Generative_AV_Performan/
+---
+
 <!-- Filename: 3_Generative_AV_Performance_Tools.md -->
 # 3) Generative A/V & Performance Tools
 

--- a/research/Instruments_DSP_Control.md
+++ b/research/Instruments_DSP_Control.md
@@ -1,3 +1,9 @@
+---
+title: "Instruments, DSP & Control"
+layout: default
+permalink: /research/Instruments_DSP_Control/
+---
+
 <!-- Filename: 1_Instruments_DSP_Control.md -->
 # 1) Instruments, DSP & Control
 

--- a/research/Pedagogy_as_Research.md
+++ b/research/Pedagogy_as_Research.md
@@ -1,3 +1,9 @@
+---
+title: "Pedagogy-as-Research (Courses as Methods)"
+layout: default
+permalink: /research/Pedagogy_as_Research/
+---
+
 <!-- Filename: 5_Pedagogy_as_Research.md -->
 # 5) Pedagogy-as-Research (Courses as Methods)
 

--- a/research/Robotics_ROV_Aerial_Med.md
+++ b/research/Robotics_ROV_Aerial_Med.md
@@ -1,3 +1,9 @@
+---
+title: "Robotics, ROV & Aerial Media"
+layout: default
+permalink: /research/Robotics_ROV_Aerial_Med/
+---
+
 <!-- Filename: 4_Robotics_ROV_Aerial_Media.md -->
 # 4) Robotics, ROV & Aerial Media
 

--- a/research/Vision_Consent_Image_Sy.md
+++ b/research/Vision_Consent_Image_Sy.md
@@ -1,3 +1,9 @@
+---
+title: "Vision, Consent & Image Systems"
+layout: default
+permalink: /research/Vision_Consent_Image_Sy/
+---
+
 <!-- Filename: 2_Vision_Consent_Image_Systems.md -->
 # 2) Vision, Consent & Image Systems
 


### PR DESCRIPTION
## Summary
- add Jekyll front matter with titles, layout, and permalinks to the research notebook markdown files so they render within the site shell
- retain existing annotations (filename comments, last-updated notes) below the new front matter blocks for proper markdown conversion

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb8e3a9e0832585d54deb4890e3c4