### PR TITLE
Expand archive list with full legacy site index

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -282,6 +282,19 @@ a:focus-visible {
   border-radius: 0.85rem;
   background: var(--surface);
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.legacy-list h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+.legacy-lede {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 .legacy-list a {
   font-weight: 700;
@@ -298,6 +311,27 @@ a:focus-visible {
   color: var(--muted);
   font-size: 0.95rem;
   line-height: 1.4;
+}
+.legacy-sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+.legacy-sublist li {
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.legacy-sublist a {
+  font-weight: 600;
+}
+.legacy-sublist span {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
 }
 
 .news-list {

--- a/index.html
+++ b/index.html
@@ -126,24 +126,244 @@
           <h3 id="legacy-links-title">Legacy quick links</h3>
           <ul class="legacy-list">
             <li>
-              <a href="/2d/banners.html">2D · Banners</a>
-              <span>Early signal-flag print experiments.</span>
+              <h4>Jekyll-era hub pages</h4>
+              <p class="legacy-lede">The original navigation stack is still alive if you want the pre-refresh framing.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/studio/">Studio Portfolio (Jekyll)</a>
+                  <span>Legacy card grid pulling directly from the `_projects` collection.</span>
+                </li>
+                <li>
+                  <a href="/teaching/">Academic Portfolio (Jekyll)</a>
+                  <span>Original teaching brief index rendered via `_teaching`.</span>
+                </li>
+                <li>
+                  <a href="/about/">About / CV</a>
+                  <span>Long-form bio, CV timeline, and document download hub.</span>
+                </li>
+                <li>
+                  <a href="/contact/">Contact (legacy)</a>
+                  <span>Email-first contact page that predates the new media-facing version.</span>
+                </li>
+                <li>
+                  <a href="/critical-digital-studies-sampler/">Critical Digital Studies Sampler</a>
+                  <span>Course reader landing page with theory + practice pairings.</span>
+                </li>
+              </ul>
             </li>
             <li>
-              <a href="/3d/genfab.html">3D · GenFab prototype</a>
-              <span>Fabrication lab build notes and photos.</span>
+              <h4>Project case studies</h4>
+              <p class="legacy-lede">Every collection entry that once drove the homepage grid is still linkable.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/projects/mn42/">MOARkNOBS-42</a>
+                  <span>Open-hardware MIDI controller notes, galleries, and repo links.</span>
+                </li>
+                <li>
+                  <a href="/projects/glitch-geometry/">Glitch Geometry</a>
+                  <span>Speculative CAD experiments where parametric errors become form.</span>
+                </li>
+                <li>
+                  <a href="/projects/dataweird/">Data Weird</a>
+                  <span>Hackathon-born data sculpture with live visuals and sensor mashups.</span>
+                </li>
+              </ul>
             </li>
             <li>
-              <a href="/spin/">Spin</a>
-              <span>Legacy p5.js sketches keeping the motion studies alive.</span>
+              <h4>Teaching briefs</h4>
+              <p class="legacy-lede">Use these for syllabi comparisons or to raid the artifact lists.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/teaching/creative-coding/">Creative Coding 101</a>
+                  <span>Processing and p5.js primer with peer-iteration rituals.</span>
+                </li>
+                <li>
+                  <a href="/teaching/critical-making/">Critical Making — Day One</a>
+                  <span>Workshop sprint mixing critical design readings with solder fumes.</span>
+                </li>
+                <li>
+                  <a href="/teaching/media2-mtn/">MCAD Media 2 — MTN Broadcast</a>
+                  <span>Broadcast studio bootcamp with ethics checkpoints baked in.</span>
+                </li>
+              </ul>
             </li>
             <li>
-              <a href="/text/text_program1.html">Text Program 1</a>
-              <span>Poetic systems research from the early archive.</span>
+              <h4>Research notebooks</h4>
+              <p class="legacy-lede">Methods, assumption ledgers, and measurement labs from the previous build.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/research/">Research index</a>
+                  <span>Portal that originally stitched all notebooks together.</span>
+                </li>
+                <li>
+                  <a href="/research/privacy-ethics/">Privacy &amp; Ethics (v0.1)</a>
+                  <span>Baseline commitments for consent-forward sensing and documentation.</span>
+                </li>
+                <li>
+                  <a href="/research/facetimes-assumptions/">Human-Buffer Assumption Ledger</a>
+                  <span>Legacy faceTimes log that tracks consent checkpoints and risks.</span>
+                </li>
+                <li>
+                  <a href="/research/mn42-latency-lab/">MN42 Latency Lab</a>
+                  <span>Benchmarking workflow for measuring controller responsiveness.</span>
+                </li>
+                <li>
+                  <a href="/research/Documentation_Ethics_Me/">Documentation, Ethics &amp; Meta-Research</a>
+                  <span>Notes on how evidence is gathered, annotated, and shared.</span>
+                </li>
+                <li>
+                  <a href="/research/Fabrication_Systems_Met/">Fabrication Systems &amp; Methods</a>
+                  <span>Shop process documentation for fabrication labs and residencies.</span>
+                </li>
+                <li>
+                  <a href="/research/Generative_AV_Performan/">Generative A/V &amp; Performance Tools</a>
+                  <span>Signal chains for live visuals and sound instruments.</span>
+                </li>
+                <li>
+                  <a href="/research/Instruments_DSP_Control/">Instruments, DSP &amp; Control</a>
+                  <span>Controller design notes and DSP building blocks.</span>
+                </li>
+                <li>
+                  <a href="/research/Pedagogy_as_Research/">Pedagogy-as-Research</a>
+                  <span>Course design treated as inquiry with documentation rituals.</span>
+                </li>
+                <li>
+                  <a href="/research/Robotics_ROV_Aerial_Med/">Robotics, ROV &amp; Aerial Media</a>
+                  <span>Field notes on remote vehicle builds and camera rigs.</span>
+                </li>
+                <li>
+                  <a href="/research/Vision_Consent_Image_Sy/">Vision, Consent &amp; Image Systems</a>
+                  <span>Research log on computer vision pipelines with agency safeguards.</span>
+                </li>
+              </ul>
             </li>
             <li>
-              <a href="/robot/">Robot Lab prototypes</a>
-              <span>Documentation of the robotics teaching rigs.</span>
+              <h4>2D works archive</h4>
+              <p class="legacy-lede">Full-bleed documentation pages for print and flag experiments.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/2d/banners.html">Banners</a>
+                  <span>Signal-flag series with critical text overlays.</span>
+                </li>
+                <li>
+                  <a href="/2d/divine.html">Jacskass</a>
+                  <span>Photographic collage digging into devotion and spectacle.</span>
+                </li>
+                <li>
+                  <a href="/2d/hate.html">The truth is, I hate to tell you</a>
+                  <span>Poster-scale print investigation into language and protest.</span>
+                </li>
+                <li>
+                  <a href="/2d/stalker.html">Nightstalker Re-Runs on Channel 4</a>
+                  <span>Newsprint experiments on surveillance and late-night media.</span>
+                </li>
+                <li>
+                  <a href="/2d/untitled.html">Untitled (an act of war)</a>
+                  <span>Large-format print pairing militarized graphics with poetry.</span>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <h4>3D works archive</h4>
+              <p class="legacy-lede">Installations, sculptures, and kinetic builds documented pre-refresh.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/3d/bath.html">Digital Bath / Engram</a>
+                  <span>Immersive installation co-built with N. Knutson.</span>
+                </li>
+                <li>
+                  <a href="/3d/call.html">Delay hasn't cost me a thing</a>
+                  <span>Time-delay sculpture study with layered projections.</span>
+                </li>
+                <li>
+                  <a href="/3d/choke.html">I hope you choke</a>
+                  <span>Machined forms and lighting tuned around suffocation metaphors.</span>
+                </li>
+                <li>
+                  <a href="/3d/con.html">Construct / Obstruct</a>
+                  <span>Architectural intervention with blocking planes and light.</span>
+                </li>
+                <li>
+                  <a href="/3d/fly.html">Are you ready to fly?</a>
+                  <span>Interactive build exploring flight training rhetoric.</span>
+                </li>
+                <li>
+                  <a href="/3d/genfab.html">Generative Fabrication Techniques</a>
+                  <span>Fabrication lab prototype documentation and design sketches.</span>
+                </li>
+                <li>
+                  <a href="/3d/lie.html">I'd never lie to you</a>
+                  <span>Speculative object series on trust and interface.</span>
+                </li>
+                <li>
+                  <a href="/3d/party.html">I can't tell where to begin</a>
+                  <span>Room-scale installation riffing on celebration and collapse.</span>
+                </li>
+                <li>
+                  <a href="/3d/redstairs.html">Red Stairs / Somebody please save us</a>
+                  <span>Staged environment with cascading red architectural elements.</span>
+                </li>
+                <li>
+                  <a href="/3d/truth.html">We hold these truths</a>
+                  <span>Installation pairing sculptural forms with civic text.</span>
+                </li>
+                <li>
+                  <a href="/3d/war.html">They're preparing for war</a>
+                  <span>Industrial assemblage documenting escalation and defense.</span>
+                </li>
+                <li>
+                  <a href="/3d/warning.html">I'd never lie to you (warning)</a>
+                  <span>Companion lighting study from the warning-series sculptures.</span>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <h4>Interactive &amp; text experiments</h4>
+              <p class="legacy-lede">The browser-native sketches and readings that anchored the prior archive.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/spin/">Spin</a>
+                  <span>p5.js motion studies keeping the kinetic research public.</span>
+                </li>
+                <li>
+                  <a href="/robot/">Robot Lab prototypes</a>
+                  <span>Browser-based documentation of robotics teaching rigs.</span>
+                </li>
+                <li>
+                  <a href="/text/text_program1.html">Text Program 1</a>
+                  <span>Poetic systems research from the early writing archive.</span>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <h4>Legacy downloads</h4>
+              <p class="legacy-lede">Syllabi, briefs, and print profiles that used to hide in the footer.</p>
+              <ul class="legacy-sublist">
+                <li>
+                  <a href="/text/SP19_FDN141105_IdeationandProcess_Severns.docx">SP19 Ideation &amp; Process syllabus</a>
+                  <span>Foundation course outline and assignment pacing.</span>
+                </li>
+                <li>
+                  <a href="/text/SP19_SC308201_SculptureStudio_%20Arduino_Severns.docx">SP19 Sculpture Studio · Arduino</a>
+                  <span>Hybrid sculpture/electronics workshop plan.</span>
+                </li>
+                <li>
+                  <a href="/text/SP20_WMM308501_ExperimentalSoundDesign_Severns.docx">SP20 Experimental Sound Design</a>
+                  <span>Broadcast-ready sound design syllabus with project ladder.</span>
+                </li>
+                <li>
+                  <a href="/text/SP23_FDN131102_Foundation_%20Media1_Severns.docx">SP23 Foundation Media 1</a>
+                  <span>Intro media lab scaffolding documentation.</span>
+                </li>
+                <li>
+                  <a href="/text/SP23_FDN131203_Foundation_%20Media2_Severns.docx">SP23 Foundation Media 2</a>
+                  <span>Follow-up course schedule with media literacy focus.</span>
+                </li>
+                <li>
+                  <a href="/text/genF1-petg.curaprofile">GenF1 PETG Cura profile</a>
+                  <span>3D printer settings file from the fabrication bench.</span>
+                </li>
+              </ul>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
- replace the short archive note list with grouped navigation that surfaces every legacy page, project, and download from the pre-refresh site
- add styling hooks so the expanded legacy list renders nested categories cleanly

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dfbec274008325b650f8f2473a7e9f