### PR TITLE
Expand Creative Coding and Critical Making briefs

### DIFF
--- a/_teaching/creative-coding.md
+++ b/_teaching/creative-coding.md
@@ -21,3 +21,51 @@ artifacts: ["Syllabus snippet", "Starter code"]
 updated: "2025-08-20"
 featured: true
 ---
+
+## Course vibe
+This lab is a zero-to-one ramp for students who want to sketch with pixels, sound, and motion while keeping one foot in critical media literacy. We wire intent to technique: every mini-lesson swings between code walkthroughs, documentation rituals, and peer critiques that keep experimentation accountable.
+
+## Studio arc (12-week sample)
+| Week | Focus | Repo artifacts we raid |
+| --- | --- | --- |
+| 1–2 | Pixel arrays + input/output chain | [`MEDIA2-codeEXPLAINERS`](https://github.com/bseverns/Syllabus/tree/main/MCADMedia2/MEDIA2-codeEXPLAINERS) — `animate2`, `animation`, and `snake` sketches scaffold conditionals, loops, and DOM hooks before students remix them live. |
+| 3–4 | Glitch as systems literacy | [`glitchProcessing`](https://github.com/bseverns/glitchProcessing) — `ChannelShiftGlitch` for channel swapping, `noise_glitch` for `get()`/`copy()` collage drills, and `video_glitch` / `webcam_glitch` for motion pipelines. |
+| 5–6 | Audio-reactive geometry | [`GlitchListener`](https://github.com/bseverns/GlitchListener) — lab notebooks map feature extraction to visuals; pairs with the Processing Minim tutorials inside the repo. |
+| 7–8 | Networked sketch swaps | [`Syllabus`](https://github.com/bseverns/Syllabus/tree/main/MCADMedia2) briefs for peer handoffs; learners document “what changed, why, and what to test next” following the shared policies. |
+| 9–10 | Story-driven systems | Pull briefs from [`MCADMedia1`](https://github.com/bseverns/Syllabus/tree/main/MCADMedia1) to push narrative into the sketchbook. |
+| 11–12 | Capstone jam | Students either harden a favorite sketch or port it to performance (OBS, projection, or embedded display). Documentation becomes the artifact. |
+
+## How we run the room
+- **Daily warm-up:** 10-minute “code karaoke” where one student live-narrates a repo sketch (often `MEDIA2-codeEXPLAINERS/animation` or `flexibleParents`) while the cohort annotates intent, inputs, and outputs.
+- **Live coding blocks:** Instructor demos from `glitchProcessing`, toggling parameters while the projector shows the README snippets that explain the glitch logic. Students fork immediately and push remixes to a shared GitHub Classroom.
+- **Crit stacks:** Peers rotate through roles (reader, tester, documentarian) and leave issues/PR comments instead of compliments. Everyone cites line numbers or commits.
+- **Documentation sweeps:** Every Friday is a README clinic. Learners update their repo landing pages to read like a studio notebook: intent, setup, what broke, and how to remix.
+
+## Sample assignments
+1. **Pixel Habit Loop** — Clone `animate2` and `snake`, record every experiment in a `process.md` with screenshots, and publish the GitHub Classroom link for critique.
+2. **Glitch Triptych** — Use `ChannelShiftGlitch`, `noise_glitch`, and `Transform_SlitScan` from `glitchProcessing` to produce three outputs that share one dataset. Annotate how each algorithm transforms the source image and include failure notes.
+3. **Video Pipeline Autopsy** — Start from `MEDIA2-codeEXPLAINERS/video` and remix it into a webcam-based performance. Document the event chain (input → buffer → transform → output) and add toggles for peers to test.
+4. **Peer Remix Relay** — Swap sketches at midterm. Each student forks a peer’s repo, adds a new feature (input mode, modulation, or documentation upgrade), and submits a PR with annotated commits.
+
+## Assessment signals
+- Process notebook (weekly commits, README updates, screenshots, and annotated bugs)
+- Peer feedback logs (issues/PRs showing how they supported each other’s builds)
+- Final performance/demo (5-minute show-and-tell with code walkthrough and failure postmortem)
+- Self-critique (connect their work to accessibility, consent, or authorship standards borrowed from `Syllabus/shared/policies`)
+
+## Accessibility + infrastructure
+- All repo README files must land with alt text, keyboard shortcuts listed in plain text, and a `SETUP.md` for classmates using screen readers or alternative input devices.
+- The class GitHub organization keeps Issues templates for `Bug`, `Idea`, and `Documentation` so students learn to log things transparently.
+- Labs run on open-source tooling: Processing, p5.js web editor, VS Code + Live Server, or Glitch. Loaner laptops come preloaded with the Processing sketchbook that mirrors the teaching repos.
+
+## Remix prompts
+- Port `noise_glitch` or `ChannelShiftGlitch` to p5.js and log the differences in APIs, build pipeline, and performance.
+- Swap the audio feature extractor in `GlitchListener` for a hand-rolled FFT and compare results in a zine (two pages minimum, printed or PDF).
+- Collab with Media Studies: use the `Skyway Dérive / Media Fast` prompts from the Syllabus repo as the conceptual brief, then respond with a generative sketch instead of a written essay.
+
+## Links to raid
+- `MEDIA2-codeEXPLAINERS` (p5.js demos): <https://github.com/bseverns/Syllabus/tree/main/MCADMedia2/MEDIA2-codeEXPLAINERS>
+- Glitch Processing Study Hall: <https://github.com/bseverns/glitchProcessing>
+- SonicSketches starter pack: <https://github.com/bseverns/SonicSketches>
+- Syllabus shared policies: <https://github.com/bseverns/Syllabus/tree/main/shared/policies>
+- GitHub Classroom template (internal): ask for access — we rotate invites each semester.

--- a/_teaching/critical-making.md
+++ b/_teaching/critical-making.md
@@ -21,3 +21,53 @@ artifacts: ["Day-one brief", "Circuit diagram"]
 updated: "2025-09-01"
 featured: true
 ---
+
+## Workshop tone
+Critical Making Day One is a mashup of theory, solder, and consent culture. We prime the room with readings (Dunne & Raby, Ruha Benjamin, Corita Kent’s Ten Rules) and immediately drop into builds pulled from our teaching repos so participants feel the politics in their hands.
+
+## Day-one itinerary (6-hour sprint)
+| Time | Move | Repo anchor |
+| --- | --- | --- |
+| 0:00–0:20 | Welcome + “Why build at all?” dialogue | [Syllabus shared policies](https://github.com/bseverns/Syllabus/tree/main/shared/policies) for community agreements |
+| 0:20–1:10 | **Consent-forward vision demo** — run Face → Slug | [`Human-Buffer`](https://github.com/bseverns/Human-Buffer) README + Ethics zine |
+| 1:10–1:30 | Reflection circle + ledger mapping | `Human-Buffer/docs/assumption-ledger.md` |
+| 1:30–2:30 | **Circuit riot lab** — solder + prototype noise makers | [`ArduinoSculpture_MCAD`](https://github.com/bseverns/ArduinoSculpture_MCAD) unit kits |
+| 2:30–3:15 | Lunch + “documentation is an artifact” zine jam | Pull quotes from `ArduinoSculpture_MCAD/unit5/README.md` + `build_kits.py` workflow |
+| 3:15–4:15 | **Embodied interface teardown** — map agency in MOARkNOBS-42 | [`MOARkNOBS-42`](https://github.com/bseverns/MOARkNOBS-42) docs & button map |
+| 4:15–5:15 | **Systems rehearsal** — MotorLightSound state machine | [`MotorLightSound`](https://github.com/bseverns/MotorLightSound) firmware walkthrough |
+| 5:15–6:00 | Pop-up critique + action pledges | Everyone logs issues/PRs or writes reflection cards |
+
+## Demo rigs & repo pulls
+- **Face → Slug (Privacy-First)** — Use the Processing + Arduino workflow to show detection-only pipelines, opt-in capture, and the assumption ledger habit. The README doubles as a facilitator script, covering logistics, standards alignment, troubleshooting, and serial protocol diagrams so the group can interrogate every decision.
+- **Arduino Sculpture kits** — Run `python build_kits.py` from `ArduinoSculpture_MCAD` to generate clean `Unit-Kit.zip` bundles. Participants inspect the generated `sketches/`, `libraries/`, and `docs/Unit-Guide.pdf` to see how automation supports equitable access.
+- **MOARkNOBS-42 interface audit** — Crack open the `ButtonManager` table and the ethics section in the README. Learners trace agency, latency logs, and accessibility design to question who the instrument serves.
+- **MotorLightSound game loop** — The README’s hardware diagram and state machine renderings become conversation starters about cooperative multitasking, documentation clarity, and how embedded systems embed politics.
+
+## Facilitation tactics
+- Start each build with a **values checkpoint**: name who benefits, who’s left out, and how the repo’s policies address that gap.
+- Use **documentation karaoke** — participants read repo excerpts aloud (assumption ledgers, testing rituals, README quick starts) so the ethos sticks alongside the code.
+- Encourage **issue-filing as critique**. Every team logs at least one issue in the appropriate repo, framing observations as actionable prompts rather than passive notes.
+- Close each block with a **“what broke?” round**. Failure stories become the blueprint for next steps.
+
+## Assessment & artifacts
+- **Setup ledger** — teams capture their wiring diagrams, software versions, and consent signage in a shared markdown doc.
+- **Reflection memo** — 300–500 words tying their prototype to at least one standard (science, arts, CS) and citing the repo docs they leaned on.
+- **Issue or PR** — evidence of engagement with open-source workflow (bug report, documentation patch, or feature proposal).
+
+## Safety, access, & care
+- Tool library includes loaner soldering irons, fume extractors, magnifiers, and anti-fatigue mats. Breaks are enforced.
+- All demo stations post safety cards plus QR links to repo READMEs so participants can review on their own devices.
+- Sensory considerations: offer ear protection during noise demos, caption demo videos, and keep lighting adjustable.
+- We only capture photos/video after an explicit opt-in; otherwise documentation stays text-based.
+
+## Remix + follow-up ideas
+- Extend the workshop into a 3-week studio where teams fork `Human-Buffer` to design alternative input devices (foot pedals, gaze, gesture) and update the assumption ledger accordingly.
+- Pair `MOARkNOBS-42` with `MotorLightSound` to explore telepresence or distributed control — map the ethics of remote agency.
+- Invite community partners to test the prototypes and record oral histories (with consent) to weave qualitative data into the repo documentation.
+
+## Link stash
+- Human-Buffer teaching build: <https://github.com/bseverns/Human-Buffer>
+- Arduino Sculpture course repo: <https://github.com/bseverns/ArduinoSculpture_MCAD>
+- MOARkNOBS-42 instrument lab: <https://github.com/bseverns/MOARkNOBS-42>
+- MotorLightSound teaching lab: <https://github.com/bseverns/MotorLightSound>
+- Syllabus shared policies + critique scaffolds: <https://github.com/bseverns/Syllabus/tree/main/shared/policies>


### PR DESCRIPTION
## Summary
- expand the Creative Coding 101 page with studio arc, assignments, and repo links pulled from the teaching repositories
- build out the Critical Making Day One workshop page with a detailed itinerary, demo rigs, facilitation tactics, and follow-up ideas

## Testing
- bundle exec jekyll build *(fails: repo does not include a Gemfile or bundled config so the command cannot run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc79d52f88325ba5e508b12304044