### PR TITLE
Polish legacy layouts and update Human Buffer references

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,9 @@
     </div>
   </header>
   <main id="main" class="site-main" tabindex="-1">
-    {{ content }}
+    <div class="content-area">
+      {{ content }}
+    </div>
   </main>
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">

--- a/_projects/dataweird.md
+++ b/_projects/dataweird.md
@@ -3,8 +3,8 @@ title: "Data Weird"
 year: 2023
 media: "Workshop installation"
 context: "Collaborative prototype"
-hero: /assets/images/cds/ds200801-still.png
-hero_alt: "Projection-mapped acrylic tower responding to live particulate sensor data during the overnight jam"
+hero: /img/portfolio/3d/genF1.jpg
+hero_alt: "genF1 PETG print from the Generative Fabrication series, ribboned isosurface with cellular cavities"
 summary: "An overnight data sculpture jam where live sensors drive projection-mapped acrylic towers and invite walk-up debugging."
 featured: true
 tools: "TouchDesigner for live visuals, Python data wrangling scripts, Arduino sensor array, LED sculpture fabrication"

--- a/css/site.css
+++ b/css/site.css
@@ -123,6 +123,169 @@ a:focus-visible {
   margin: 0 auto;
 }
 
+.content-area {
+  width: min(100% - 2rem, 960px);
+  margin: 0 auto;
+  padding: clamp(40px, 8vw, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 48px);
+}
+
+.content-area > * {
+  max-width: 100%;
+}
+
+.content-area h1 {
+  font-size: clamp(2.5rem, 4vw + 1rem, 3.75rem);
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.content-area h2 {
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+  margin: clamp(24px, 4vw, 48px) 0 0.6em;
+}
+
+.content-area h3 {
+  font-size: clamp(1.35rem, 1.5vw + 0.9rem, 1.8rem);
+  margin: clamp(18px, 3vw, 32px) 0 0.5em;
+}
+
+.content-area p {
+  margin: 0;
+  max-width: 72ch;
+  color: var(--fg);
+}
+
+.content-area p + p,
+.content-area p + ul,
+.content-area p + ol,
+.content-area ul + p,
+.content-area ol + p {
+  margin-top: 1rem;
+}
+
+.content-area ul,
+.content-area ol {
+  padding-left: 1.5rem;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.content-area li {
+  max-width: 70ch;
+}
+
+.content-area blockquote {
+  border-left: 4px solid var(--brand);
+  padding-left: 1rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.content-area pre {
+  background: var(--surface-muted);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+.content-area code {
+  font-family: "Source Code Pro", Menlo, monospace;
+  font-size: 0.95em;
+  background: var(--surface-muted);
+  border-radius: 0.4rem;
+  padding: 0.15rem 0.35rem;
+}
+
+.content-area table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.content-area th,
+.content-area td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.content-area tr:last-child td {
+  border-bottom: none;
+}
+
+.content-area img,
+.content-area video,
+.content-area iframe {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.9rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+article.project,
+article.teaching {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: clamp(28px, 5vw, 48px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+article.project .meta,
+article.teaching .meta {
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+article.project .hero {
+  width: 100%;
+  border-radius: 1rem;
+  margin: clamp(24px, 4vw, 40px) 0;
+  border: 1px solid var(--border);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.1);
+}
+
+article.project h2,
+article.teaching h2 {
+  margin-top: clamp(28px, 4vw, 48px);
+}
+
+article.project ul,
+article.teaching ul {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+article.project li,
+article.teaching li {
+  max-width: 68ch;
+}
+
+@media (max-width: 720px) {
+  .content-area {
+    width: min(100% - 1.5rem, 960px);
+    padding: clamp(32px, 10vw, 72px) 0;
+  }
+
+  article.project,
+  article.teaching {
+    padding: clamp(24px, 8vw, 40px);
+  }
+}
+
 .hero {
   background: var(--surface);
   padding: 4rem 0;
@@ -763,20 +926,30 @@ a:focus-visible {
 
 @media (min-width: 900px) {
   .updates-grid {
-    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
     align-items: start;
+    grid-auto-rows: minmax(0, max-content);
   }
 
   .updates-grid > .now-next {
     position: sticky;
     top: clamp(72px, 12vw, 140px);
     align-self: start;
+    z-index: 1;
   }
 
   .updates-grid > .playable {
-    position: sticky;
-    top: clamp(160px, 18vw, 260px);
-    align-self: start;
+    grid-column: 2;
+    position: static;
+    top: auto;
+    align-self: stretch;
+  }
+
+  .updates-grid > .patch-notes {
+    grid-column: 2;
+    margin-top: clamp(20px, 3vw, 40px);
+    position: relative;
+    z-index: 0;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <h2 id="nn-heading">What’s on the bench</h2>
           <ul class="nn-list">
             <li><strong>Now:</strong> MN42 v0.2 tuning + latency notes.</li>
-            <li><strong>Next:</strong> faceTimes refactor (opt-in gate + delete-now).</li>
+            <li><strong>Next:</strong> Human Buffer refactor (opt-in gate + delete-now).</li>
             <li><strong>Proofs:</strong> Innovation &amp; 3D Printing kit refresh; quick-starts.</li>
           </ul>
         </section>
@@ -82,7 +82,7 @@
           <h2 id="patch-heading">Patch notes</h2>
           <ul>
             <li><a href="https://github.com/bseverns/MOARkNOBS-42" target="_blank" rel="noopener">MN42</a> — mapping manifest tweaks</li>
-            <li><a href="https://github.com/bseverns/faceTimes" target="_blank" rel="noopener">faceTimes</a> — consent gate refactor</li>
+            <li><a href="https://github.com/bseverns/Human-Buffer" target="_blank" rel="noopener">Human Buffer</a> — consent gate refactor</li>
             <li><a href="/courses.html">Courses</a> — station cards consolidated</li>
           </ul>
         </section>
@@ -201,7 +201,7 @@
                 </li>
                 <li>
                   <a href="/research/facetimes-assumptions/">Human-Buffer Assumption Ledger</a>
-                  <span>Legacy faceTimes log that tracks consent checkpoints and risks.</span>
+                  <span>Legacy Human Buffer log (formerly faceTimes) that tracks consent checkpoints and risks.</span>
                 </li>
                 <li>
                   <a href="/research/mn42-latency-lab/">MN42 Latency Lab</a>


### PR DESCRIPTION
## Summary
- wrap the default layout content in a `.content-area` container and add typography/image rules so legacy markdown, project, and teaching pages render cleanly
- rework the home page updates grid so Patch notes flows in its own column instead of hiding behind the sticky "What’s on the bench" card
- swap the Data Weird hero image to the Generative Fabrication portfolio still and update landing copy to use the Human Buffer name

## Testing
- Manual verification: `python3 -m http.server 8000` and inspected http://127.0.0.1:8000/index.html


------
https://chatgpt.com/codex/tasks/task_e_68dfdb79e2508325be60a2b888dea41a