### PR TITLE
Dial back public sampler references

### DIFF
--- a/art.html
+++ b/art.html
@@ -1,7 +1,7 @@
 ---
 layout: null
 title: "Studio Portfolio"
-seo_description: "Selected studio projects by Ben Severns"
+seo_description: "Consent-aware installations and instruments documented with assumption ledgers and civic context"
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -50,7 +50,7 @@ seo_description: "Selected studio projects by Ben Severns"
       <div class="container">
         <p class="eyebrow">Scenes, installations, instruments</p>
         <h1>{{ page.title }}</h1>
-        <p>Hover or tap a card to get the gist; click through for the full noise.</p>
+        <p>Critical inquiry meets hands-on builds—every project makes its technical and ethical layers legible so you can audit, remix, and redeploy it.</p>
         <div class="cta">
           <a class="btn secondary" href="/#archive-note-title">Dig through the archive stacks ↗</a>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Contact · Ben Severns</title>
-  <meta name="description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <meta name="description" content="Contact Ben Severns to co-build consent-forward instruments, civic media, and justice-centered curricula.">
   <link rel="canonical" href="https://bseverns.github.io/contact.html">
   <link rel="stylesheet" href="/css/site.css">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Contact · Ben Severns">
-  <meta property="og:description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <meta property="og:description" content="Contact Ben Severns to co-build consent-aware instruments, civic media, and justice-centered curricula.">
   <meta property="og:url" content="https://bseverns.github.io/contact.html">
   <meta property="og:image" content="/img/social/og-banner.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Contact · Ben Severns">
-  <meta name="twitter:description" content="Contact Ben Severns for studio or teaching collaborations, media, and documentation support.">
+  <meta name="twitter:description" content="Contact Ben Severns to co-build consent-aware instruments, civic media, and justice-centered curricula.">
   <meta name="twitter:image" content="/img/social/og-banner.jpg">
   <script defer src="/js/site.js"></script>
   <script type="application/ld+json">
@@ -55,14 +55,14 @@
         </ol>
       </nav>
       <h1>Contact</h1>
-      <p>I’m happy to connect about co-building, teaching collaborations, documentation strategy, or performances. Bots and scraper farms get bounced.</p>
+      <p>Reach out when you want to pair critical inquiry with hands-on digital practice—co-building consent-forward instruments, civic media, justice-centered curricula, or the documentation to hold it all accountable. Bots and scraper farms get bounced.</p>
     </div>
 
     <section class="contact-section" aria-labelledby="contact-direct">
       <div class="container">
         <h2 id="contact-direct">Reach me directly</h2>
         <ul class="contact-list">
-          <li><a href="mailto:hello@bseverns.me">hello@bseverns.me</a> — best for project starts and resource requests.</li>
+          <li><a href="mailto:hello@bseverns.me">hello@bseverns.me</a> — best for project starts, assumption ledgers, and resource requests.</li>
           <li><a href="https://www.linkedin.com/in/bseverns">LinkedIn</a> — professional context, intros, references.</li>
           <li><a href="https://github.com/bseverns">GitHub</a> — follow along with open tooling and documentation repos.</li>
         </ul>

--- a/courses.html
+++ b/courses.html
@@ -1,7 +1,7 @@
 ---
 layout: null
 title: "Teaching"
-seo_description: "Courses, workshops, and residencies led by Ben Severns"
+seo_description: "Systems-first teaching that ties digital literacy to justice, representation, and civic engagement"
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -50,7 +50,7 @@ seo_description: "Courses, workshops, and residencies led by Ben Severns"
       <div class="container">
         <p class="eyebrow">Courses, workshops, residencies</p>
         <h1>{{ page.title }}</h1>
-        <p>I teach digital performance, creative coding, and community-first tech. Every syllabus lives in the open.</p>
+        <p>Working systems-first, I make technical and ethical layers legible so students can audit, extend, and treat media as civic instruments.</p>
         <div class="cta">
           <a class="btn" href="https://github.com/bseverns/Syllabus">Raid the Syllabus repo ↗</a>
           <a class="btn secondary" href="/contact.html">Bring me to your program ↗</a>
@@ -70,8 +70,8 @@ seo_description: "Courses, workshops, and residencies led by Ben Severns"
     <section class="teaching-note">
       <div class="container">
         <h2>How I run my classrooms</h2>
-        <p>Build-first. Document everything. Critique with generosity and rigor. Students leave with shippable tools, not vapor.</p>
-        <p>Need a custom workshop, staff training, or research residency? <a href="/contact.html">Hit me up</a> and let's plot it.</p>
+        <p>Build-first, document loudly, and thread justice/representation questions through every station card. Consent, access, and civic impact get treated as features—not footnotes.</p>
+        <p>Need a custom workshop, staff training, or research residency? <a href="/contact.html">Hit me up</a> and let's build the assumption ledger together.</p>
       </div>
     </section>
   </main>

--- a/index.html
+++ b/index.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ben Severns — Artist · Educator · Systems</title>
-  <meta name="description" content="Open instruments, consent-forward sensing, and practical curricula — documented so others can build.">
+  <meta name="description" content="Critical inquiry + hands-on digital practice. Systems-first lab documenting consent-forward instruments, civic media, and teachable methods.">
   <link rel="canonical" href="https://bseverns.github.io/">
   <link rel="stylesheet" href="/css/site.css">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Ben Severns — Artist · Educator · Systems">
-  <meta property="og:description" content="Tools, scenes, and learning environments.">
+  <meta property="og:description" content="Critical inquiry + hands-on digital practice. Systems-first lab documenting consent-aware instruments, civic media, and teachable methods.">
   <meta property="og:url" content="https://bseverns.github.io/">
   <meta property="og:image" content="/img/social/og-banner.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Ben Severns — Artist · Educator · Systems">
-  <meta name="twitter:description" content="Tools, scenes, and learning environments.">
+  <meta name="twitter:description" content="Critical inquiry + hands-on digital practice. Systems-first lab documenting consent-aware instruments, civic media, and teachable methods.">
   <meta name="twitter:image" content="/img/social/og-banner.jpg">
   <script defer src="/js/site.js"></script>
   <script type="application/ld+json">
@@ -25,7 +25,7 @@
     "name":"Ben Severns",
     "url":"https://bseverns.github.io/",
     "jobTitle":"Artist–Educator",
-    "description":"Artist–educator building tools, scenes, and learning environments.",
+    "description":"Artist–educator pairing critical inquiry with hands-on digital practice so collaborators can audit and extend the work.",
     "sameAs":["https://github.com/bseverns","https://bseverns.github.io/","https://www.linkedin.com/in/bseverns","https://bbss.bandcamp.com/","https://www.instagram.com/42_0822.86/","https://www.mcad.edu/faculty-alumni/ben-severns","https://www.creatempls.org/about"]
   }
   </script>
@@ -51,9 +51,10 @@
     <section class="hero" data-banner="image" aria-labelledby="hero-title">
       <div class="container hero-grid">
         <div class="hero-copy">
-          <p class="eyebrow">Artist–educator in Minneapolis, MN</p>
-          <h1 id="hero-title">Tools, scenes, and learning environments</h1>
-          <p class="tagline">Systems-level practice: open instruments, consent-forward sensing, and practical curricula.</p>
+          <p class="eyebrow">Critical digital studies in practice</p>
+          <h1 id="hero-title">Critical inquiry × hands-on digital practice</h1>
+          <p class="tagline">build → perform (play, test, break) → document → iterate — the lab runs the full chain.</p>
+          <p class="tagline">Systems-first means technical and ethical layers stay legible, consent-forward, and ready for others to audit, remix, and deploy as civic instruments.</p>
           <div class="cta">
             <a class="btn" href="/art.html">Explore Studio</a>
             <a class="btn secondary" href="/courses.html">Explore Teaching</a>
@@ -68,22 +69,22 @@
         <section class="now-next" aria-labelledby="nn-heading">
           <h2 id="nn-heading">What’s on the bench</h2>
           <ul class="nn-list">
-            <li><strong>Now:</strong> MN42 v0.2 tuning + latency notes.</li>
-            <li><strong>Next:</strong> Human Buffer refactor (opt-in gate + delete-now).</li>
-            <li><strong>Proofs:</strong> Innovation &amp; 3D Printing kit refresh; quick-starts.</li>
+            <li><strong>Now:</strong> MN42 v0.2 latency lab — measuring feel before we publish the claim.</li>
+            <li><strong>Next:</strong> Human Buffer consent gate refactor with clearer assumption ledger callouts.</li>
+            <li><strong>Proofs:</strong> Innovation &amp; 3D Printing kits documenting erase-now rituals and civic use cases.</li>
           </ul>
         </section>
         <section class="playable" aria-labelledby="play-heading">
           <h2 id="play-heading">Playable</h2>
-          <p>Tap for a tiny random tone—proof of life.</p>
+          <p>Tap for a tiny random tone—small proof that the instruments stay playable while we interrogate them.</p>
           <button id="ping" class="btn secondary">make a small sound</button>
         </section>
         <section class="patch-notes" aria-labelledby="patch-heading">
           <h2 id="patch-heading">Patch notes</h2>
           <ul>
-            <li><a href="https://github.com/bseverns/MOARkNOBS-42" target="_blank" rel="noopener">MN42</a> — mapping manifest tweaks</li>
-            <li><a href="https://github.com/bseverns/Human-Buffer" target="_blank" rel="noopener">Human Buffer</a> — consent gate refactor</li>
-            <li><a href="/courses.html">Courses</a> — station cards consolidated</li>
+            <li><a href="https://github.com/bseverns/MOARkNOBS-42" target="_blank" rel="noopener">MN42</a> — latency scripts + documentation polish</li>
+            <li><a href="https://github.com/bseverns/Human-Buffer" target="_blank" rel="noopener">Human Buffer</a> — opt-in copy + delete-now ritual updated</li>
+            <li><a href="/courses.html">Courses</a> — justice-forward prompts added to station cards</li>
           </ul>
         </section>
       </div>
@@ -96,21 +97,21 @@
           <article class="card pillar">
             <div class="card-body">
               <h3>Tools</h3>
-              <p>Open instruments, kits, and supporting docs designed for remix, repair, and co-learning.</p>
+              <p>Consent-forward instruments and kits shipped with assumption ledgers, latency notes, and reproducible builds.</p>
               <a class="card-link" href="https://github.com/bseverns/MOARkNOBS-42">Read the MOARkNOBS-42 build</a>
             </div>
           </article>
           <article class="card pillar">
             <div class="card-body">
               <h3>Scenes</h3>
-              <p>Installations and performances that foreground consent-forward sensing and agency.</p>
+              <p>Installations and performances that make power, consent, and spectatorship legible in the room.</p>
               <a class="card-link" href="/art.html">Browse studio notes</a>
             </div>
           </article>
           <article class="card pillar">
             <div class="card-body">
               <h3>Learning</h3>
-              <p>Curricula, station cards, and quick-start kits that turn curiosity into replicable skill.</p>
+              <p>Curricula, station cards, and quick-start kits that tie digital literacy to justice, representation, and civic engagement.</p>
               <a class="card-link" href="/courses.html">View teaching projects</a>
             </div>
           </article>
@@ -121,7 +122,7 @@
     <section class="archive-note" aria-labelledby="archive-note-title">
       <div class="container">
         <h2 id="archive-note-title">Why the archive stays loud</h2>
-        <p>Legacy write-ups stay published for accountability. Every historical page links back here so the freshest work is one jump away.</p>
+        <p>Legacy write-ups stay published for accountability. They carry the documentation trail—assumption ledgers, privacy notes, iteration logs—so new work can cite its lineage without guesswork.</p>
         <nav class="legacy-links" aria-labelledby="legacy-links-title">
           <h3 id="legacy-links-title">Legacy quick links</h3>
           <ul class="legacy-list">
@@ -146,7 +147,7 @@
                   <span>Email-first contact page that predates the new media-facing version.</span>
                 </li>
                 <li>
-                  <a href="/critical-digital-studies-sampler/">Critical Digital Studies Sampler</a>
+                  <a href="/critical-digital-studies-sampler/">Course reader (faculty review copy)</a>
                   <span>Course reader landing page with theory + practice pairings.</span>
                 </li>
               </ul>

--- a/press-kit.html
+++ b/press-kit.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Press kit · Ben Severns</title>
-  <meta name="description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <meta name="description" content="Press resources for Ben Severns: critical inquiry × hands-on digital practice bios, quick facts, and image drop points.">
   <link rel="canonical" href="https://bseverns.github.io/press-kit.html">
   <link rel="stylesheet" href="/css/site.css">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Press kit · Ben Severns">
-  <meta property="og:description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <meta property="og:description" content="Press resources for Ben Severns: critical inquiry × hands-on digital practice bios, quick facts, and image drop points.">
   <meta property="og:url" content="https://bseverns.github.io/press-kit.html">
   <meta property="og:image" content="/img/social/og-banner.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Press kit · Ben Severns">
-  <meta name="twitter:description" content="Press resources for Ben Severns: bios, quick facts, and optional image drop points for media.">
+  <meta name="twitter:description" content="Press resources for Ben Severns: critical inquiry × hands-on digital practice bios, quick facts, and image drop points.">
   <meta name="twitter:image" content="/img/social/og-banner.jpg">
   <script defer src="/js/site.js"></script>
   <script type="application/ld+json">
@@ -55,18 +55,18 @@
         </ol>
       </nav>
       <h1>Press kit</h1>
-      <p>Use these bios and quick facts as-is. Reach out before quoting if you need a bespoke angle or accessibility format.</p>
+      <p>Use these bios and quick facts as-is. They frame the work the same way the core studio documentation does. Reach out before quoting if you need a bespoke angle or accessibility format.</p>
     </div>
 
     <section class="press-section" aria-labelledby="bio-short">
       <div class="container">
         <h2 id="bio-short">Bio (100 words)</h2>
-        <p>Ben Severns is a Minneapolis artist–educator who builds tools, scenes, and learning environments.
-His systems-first practice spans open instruments like MOARkNOBS-42, consent-forward sensing projects,
-and practical curricula for K–12 and college learners. As faculty/adjunct, he has taught at MCAD and Augsburg;
+        <p>Ben Severns is a Minneapolis artist–educator pairing critical inquiry with hands-on digital practice.
+His systems-first lab ships consent-forward instruments like MOARkNOBS-42, civic media interventions,
+and justice-tethered curricula for K–12 and college learners. As faculty/adjunct, he has taught at MCAD and Augsburg;
 as Educational Equipment &amp; Services Lead at createMPLS, he stewards large inventories and turns curiosity into skill.
-Severns documents like a researcher—assumption ledgers, mapping manifests, reproducible builds—so others can adapt,
-audit, and play. He performs and releases music as B_S_. More: bseverns.github.io · github.com/bseverns · bbss.bandcamp.com</p>
+Severns documents like a researcher—assumption ledgers, latency scripts, reproducible builds—so collaborators can audit,
+remix, and deploy the work as civic instruments. He performs and releases music as B_S_. More: bseverns.github.io · github.com/bseverns · bbss.bandcamp.com</p>
       </div>
     </section>
 
@@ -74,15 +74,14 @@ audit, and play. He performs and releases music as B_S_. More: bseverns.github.i
       <div class="container">
         <h2 id="bio-long">Bio (300 words)</h2>
         <p>Ben Severns is a systems-level educator–artist based in Minneapolis.
-He designs and publishes instruments, installations, and learning environments that invite others to build with him.
+He pairs critical inquiry with hands-on digital practice, designing instruments, installations, and learning environments that make their technical and ethical layers legible.
 His open-hardware instrument MOARkNOBS-42 pairs a Teensy-based brain with auditable documentation—assumption ledgers,
 mapping manifests, and latency bench scripts—so claims about feel, access, and ethics stay reproducible.
-Severns’s studio work leans consent-forward: detection-only kiosks, room-playing media pieces, and small provocations that
-foreground agency and documentation as part of the artwork.</p>
+Severns’s studio work stays consent-forward: detection-only kiosks, room-playing media pieces, and public provocations that treat media as civic instrument.</p>
         <p>He teaches across institutions (MCAD, Augsburg) and leads equipment/services for createMPLS, developing practical kits,
-station cards, and quick-starts that make STEAM approachable for K–12 and community learners.
+station cards, and quick-starts that tie digital literacy to justice, representation, and civic engagement for K–12 and community learners.
 As B_S_, he performs and releases long-form, glitch-lit sound collages.
-Unifying these threads is a simple measure of success: how well other people create with the tools and recipes he leaves behind.</p>
+Unifying these threads is a simple measure of success: how well other people create—with documentation, consent, and accountability—using the tools and recipes he leaves behind.</p>
       </div>
     </section>
 
@@ -92,6 +91,7 @@ Unifying these threads is a simple measure of success: how well other people cre
         <ul class="quick-facts">
           <li>Location: Minneapolis, MN</li>
           <li>Roles: Artist–Educator; Educational Equipment &amp; Services Lead (createMPLS)</li>
+          <li>Practice: Critical inquiry × hands-on digital practice; systems-first, consent-forward builds</li>
           <li>Anchor project: MOARkNOBS-42 (open instrument)</li>
           <li>Canonical handle: @bseverns</li>
           <li>Links: bseverns.github.io · github.com/bseverns · bbss.bandcamp.com</li>


### PR DESCRIPTION
## Summary
- restore the global description in `_config.yml` and tune homepage metadata so the SEO copy only nods to “consent-forward” once
- keep studio, contact, and press-kit pages aligned with the consent-aware phrasing while removing public mentions of the unlisted course reader
- ensure the legacy navigation still links to the course reader without naming the Critical Digital Studies sampler outright

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe27fdd588325b35401f0b489fc9d