### PR TITLE
Port hero flow field to superformula renderer

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -277,12 +277,22 @@
     const rootStyles = window.getComputedStyle ? getComputedStyle(document.documentElement) : null;
     const brandColor = rootStyles ? (rootStyles.getPropertyValue('--brand') || '#2563eb').trim() : '#2563eb';
     const accentColor = rootStyles ? (rootStyles.getPropertyValue('--accent') || '#1e66f5').trim() : '#1e66f5';
-    const surfaceColor = rootStyles ? (rootStyles.getPropertyValue('--surface') || '#0f172a').trim() : '#0f172a';
+    const surfaceColor = rootStyles ? (rootStyles.getPropertyValue('--surface-muted') || rootStyles.getPropertyValue('--surface') || '#0f172a').trim() : '#0f172a';
+    const focusColor = rootStyles ? (rootStyles.getPropertyValue('--accent-contrast') || '#f8fafc').trim() : '#f8fafc';
     const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const layerCount = 16;
+    const segments = 360;
+    const step = (Math.PI * 2) / segments;
+    const palette = [focusColor, brandColor, accentColor, '#f472b6'];
     let width = 0;
     let height = 0;
+    let baseScale = 0;
     let frame = 0;
-    let time = 0;
+    let clock = 0;
+    let lastTimestamp = 0;
+
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
 
     function resize() {
       width = canvas.clientWidth || (canvas.parentElement ? canvas.parentElement.clientWidth : 0) || 0;
@@ -291,56 +301,121 @@
       canvas.height = Math.max(1, Math.floor(height * DPR));
       width = width || canvas.width / DPR;
       height = height || canvas.height / DPR;
+      baseScale = Math.min(width, height) * 0.42;
       ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
       paintBackground();
     }
 
     function paintBackground() {
+      ctx.globalAlpha = 1;
       ctx.fillStyle = surfaceColor || '#0f172a';
       ctx.fillRect(0, 0, width, height);
       const gradient = ctx.createLinearGradient(0, 0, width, height);
-      gradient.addColorStop(0, accentColor || '#0ea5e9');
-      gradient.addColorStop(0.45, brandColor || '#6366f1');
-      gradient.addColorStop(1, '#ec4899');
-      ctx.globalAlpha = 0.7;
+      gradient.addColorStop(0, brandColor || '#2563eb');
+      gradient.addColorStop(0.5, accentColor || '#1e66f5');
+      gradient.addColorStop(1, '#f472b6');
+      ctx.globalAlpha = 0.45;
       ctx.fillStyle = gradient;
       ctx.fillRect(0, 0, width, height);
       ctx.globalAlpha = 1;
     }
 
-    function noise(value) {
-      return Math.sin(value * 0.0008) + Math.sin(value * 0.0013) * 0.5;
+    function superformulaRadius(phi, m, n1, n2, n3) {
+      const a = 1;
+      const b = 1;
+      let t1 = Math.cos((m * phi) / 4) / a;
+      let t2 = Math.sin((m * phi) / 4) / b;
+      t1 = Math.pow(Math.abs(t1), n2);
+      t2 = Math.pow(Math.abs(t2), n3);
+      const sum = Math.pow(t1 + t2, 1 / n1);
+      if (!isFinite(sum) || sum === 0) {
+        return 0;
+      }
+      return 1 / sum;
     }
 
-    function draw() {
-      time += 1;
-      ctx.fillStyle = 'rgba(12, 16, 32, 0.08)';
-      ctx.fillRect(0, 0, width, height);
-      for (let i = 0; i < 400; i += 1) {
-        const px = (i * 19 + time * 2) % width;
-        const py = (i * 37 + noise(time * 23 + i * 301) * 60 + height / 2) % height;
-        const angle = noise(i * 999 + time * 40) * Math.PI;
-        const length = 16 + noise(i * 13 + time * 9) * 10;
-        ctx.strokeStyle = 'hsla(' + ((i * 2 + time) % 360) + ',60%,60%,0.35)';
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        ctx.moveTo(px, py);
-        ctx.lineTo(px + Math.cos(angle) * length, py + Math.sin(angle) * length);
-        ctx.stroke();
+    // Adapted from the Visualize_Superformula Processing sketch in the dataVis repo:
+    // https://github.com/bseverns/dataVis/blob/main/Visualize_Superformula/Visualize_Superformula.pde
+    function renderFrame(elapsed, staticMode) {
+      if (!width || !height) {
+        return;
       }
+
+      if (!staticMode) {
+        ctx.globalAlpha = 0.14;
+        ctx.fillStyle = 'rgba(5, 8, 20, 0.9)';
+        ctx.fillRect(0, 0, width, height);
+        ctx.globalAlpha = 1;
+      }
+
+      ctx.save();
+      ctx.translate(width / 2, height / 2);
+      const baseRotation = Math.sin(elapsed * 0.18) * 0.25;
+      let scale = baseScale;
+
+      for (let layer = 0; layer < layerCount; layer += 1) {
+        const layerRatio = layer / Math.max(1, layerCount - 1);
+        const mm = 2 + layer * 0.35 + Math.sin(elapsed * 0.58 + layer * 0.4) * 0.9;
+        const nn1 = 18 + layer * 0.28 + Math.sin(elapsed * 0.42 + layer * 0.25) * 2.2;
+        const nn2 = 1.2 + Math.cos(elapsed * 0.36 - layer * 0.18) * 0.6;
+        const nn3 = 1.2 + Math.sin(elapsed * 0.33 + layer * 0.22) * 0.6;
+        const rotation = baseRotation + layerRatio * 0.85;
+        const color = palette[layer % palette.length];
+
+        ctx.save();
+        ctx.rotate(rotation);
+        ctx.beginPath();
+        for (let i = 0; i <= segments; i += 1) {
+          const phi = step * i;
+          const r = superformulaRadius(phi, mm, nn1, nn2, nn3);
+          const x = r * Math.cos(phi) * scale;
+          const y = r * Math.sin(phi) * scale;
+          if (i === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.closePath();
+        ctx.globalAlpha = 0.85 - layerRatio * 0.6;
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.1 + (1 - layerRatio) * 1.8;
+        ctx.stroke();
+        ctx.restore();
+
+        scale *= 0.9;
+      }
+
+      ctx.restore();
+      ctx.globalAlpha = 1;
+    }
+
+    function draw(timestamp) {
+      const seconds = (timestamp || 0) / 1000;
+      if (!lastTimestamp) {
+        lastTimestamp = seconds;
+      }
+      const delta = Math.min(0.05, Math.max(0, seconds - lastTimestamp));
+      lastTimestamp = seconds;
+      clock += delta;
+      renderFrame(clock, false);
       frame = requestAnimationFrame(draw);
     }
 
     function start() {
       cancelAnimationFrame(frame);
+      clock = 0;
+      lastTimestamp = 0;
       if (!width || !height) {
         resize();
       }
       if (motionQuery.matches) {
         paintBackground();
+        renderFrame(0, true);
         return;
       }
       paintBackground();
+      renderFrame(0, false);
       frame = requestAnimationFrame(draw);
     }
 


### PR DESCRIPTION
## Summary
- replace the hero's flowField sketch with a canvas renderer derived from the dataVis Visualize_Superformula study
- tune palette, scale, and animation parameters to echo the Processing version while keeping resize and reduced-motion behavior intact
- document the sketch reference for future maintainers

## Testing
- python3 -m http.server 8000 # previewed homepage animation

------
https://chatgpt.com/codex/tasks/task_e_68e56d1417a883258ac2a768462e5fc5