### PR TITLE
Add p5.js-driven hero motion sketch

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <meta name="twitter:title" content="Ben Severns — Artist · Educator · Systems">
   <meta name="twitter:description" content="Critical inquiry + hands-on digital practice. Systems-first lab documenting consent-aware instruments, civic media, and teachable methods.">
   <meta name="twitter:image" content="/img/social/og-banner.jpg">
+  <script defer src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.min.js"></script>
   <script defer src="/js/site.js"></script>
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Summary
- load the p5.js library and replace the hero canvas banner with a custom sketch that animates the superformula layers using the site palette
- keep reduced-motion handling, live resizing, and provide an image fallback when p5.js is unavailable

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e56ffca7d883259a005bb9b84a6bb8