### PR TITLE
Refine Studio selected works grid

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -404,6 +404,10 @@ article.teaching li {
   margin: 2rem 0 0;
 }
 
+.selected-grid {
+  margin-top: 1.5rem;
+}
+
 .card {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -434,6 +438,20 @@ article.teaching li {
   border: 1px solid var(--border);
 }
 
+.selected-card .card-thumb {
+  aspect-ratio: 4 / 3;
+  border-radius: 0.55rem;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.selected-card .card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: 0;
+}
+
 .card h3 {
   margin: 0;
   font-size: 1.35rem;
@@ -456,6 +474,21 @@ article.teaching li {
 .card-body p {
   margin: 0 0 1rem;
   color: var(--muted);
+}
+
+.archive-link-note {
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.archive-link-note a {
+  color: inherit;
+}
+
+.archive-link-note a:hover,
+.archive-link-note a:focus-visible {
+  color: var(--fg);
 }
 
 .card-link {

--- a/studio.md
+++ b/studio.md
@@ -7,12 +7,23 @@ archived: true
 ---
 # Studio Portfolio
 <p>Hover or tap a card to get the gist; click through for the full noise.</p>
-<div class="cta">
-  <a class="btn secondary" href="/#archive-note-title">
-    Dig through the archive stacks ↗
-  </a>
+
+<div class="cards selected-grid">
+{% assign featured_projects = site.projects | where: "featured", true | sort: "year" | reverse %}
+{% for item in featured_projects %}
+  <article class="card selected-card">
+    <a href="{{ item.url | relative_url }}">
+      {% if item.hero %}
+      <div class="card-thumb">
+        <img src="{{ item.hero | relative_url }}" alt="{{ item.hero_alt | default: item.title }}">
+      </div>
+      {% endif %}
+      <h3>{{ item.title }}</h3>
+      <p class="eyebrow">{{ item.year }}{% if item.media %} • {{ item.media }}{% elsif item.context %} • {{ item.context }}{% endif %}</p>
+      <p>{{ item.summary }}</p>
+    </a>
+  </article>
+{% endfor %}
 </div>
-<div class="cards">
-{% assign items = site.projects | sort: "year" | reverse %}
-{% for item in items %}{% include card.html item=item %}{% endfor %}
-</div>
+
+<p class="archive-link-note">If you prefer the deep stacks, <a href="/#archive-note-title">dig through the archive ↗</a>.</p>


### PR DESCRIPTION
## Summary
- rebuild the Studio page as a selected works grid that pulls in featured project metadata and imagery
- add inline archive link styling to de-emphasize the deep archive call-to-action

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0fb6869083259aad77ff7b180235)